### PR TITLE
Added test case for OMTG-DATAST

### DIFF
--- a/Document/Testcases/0x00_OMTG-DATAST.md
+++ b/Document/Testcases/0x00_OMTG-DATAST.md
@@ -19,7 +19,7 @@
 - OWASP MASVS: V2-1: "Verify that system credential storage facilities are used appropriately to store sensitive data, such as user credentials or cryptographic keys."
 - CWE: [Link to CWE issue]
 
-### OMTG-DATAST-009: OMTG-DATAST-009: Test for Sensitive Data in Backups
+### OMTG-DATAST-009: Test for Sensitive Data in Backups
 [General description]
 
 #### Detailed Guides

--- a/Document/Testcases/0x00a_OMTG-DATAST_Android.md
+++ b/Document/Testcases/0x00a_OMTG-DATAST_Android.md
@@ -1,20 +1,432 @@
-## <a name="OMTG-DATAST-001"></a>OMTG-DATAST-001: Test Sensitive Data Storage
+## <a name="OMTG-DATAST-001"></a>OMTG-DATAST-001: Test for Insecure Storage of Credentials and Keys
+
+An app shouldn’t store any sensitive information like credentials, passwords or encryption keys (even when using security controls and mechanisms offered by the OS as a best practice to protect this information). It should be remembered that the confidentiality of sensitive information stored locally on a device cannot be guaranteed, and that most controls can be bypassed on a rooted device.
+In case sensitive information needs to be stored, several best practices available on the OS level should be applied to make it harder for attackers to retrieve these information. 
+
+### OWASP Mobile Top 10
+M1 - Improper Platform Usage
+M2 - Insecure Data Storage
+
+### CWE
+CWE-312 - Cleartext Storage of Sensitive Information
+CWE-522 - Insufficiently Protected Credentials
 
 ### White-box Testing
 
-(Describe how to assess this with access to the source code and build configuration)
+When going through the source code it should be analyzed if native mechanisms that are offered by Android are applied to the identified sensitive information. Sensitive information should not be stored in clear text and should be encrypted. Especially encryption operations should rely on solid and tested functions provided by the SDK. The following describes different “bad practices” that should be avoided:
+* Check if simple bit operations are used, like XOR or Bit flipping to “encrypt” sensitive information like credentials or private keys that are stored locally. This should be avoided as the data can easily be recovered. 
+* Check if keys are created or used without taking advantage of the Android onboard features like the KeyStore. 
+* See also OMTG-DATAST-004 to identify what kind of information is stored persistently and if credentials or keys are disclosed.
+
+The code should also be analysed if sensitive data is used properly and securely:
+* Sensitive information should not be stored for too long in the RAM (see also “Testing for Sensitive Data Disclosure in Process Memory (OMTG-DATAST-006)”).
+* Set variables that use sensitive information to null once finished. 
+* Use immutable objects for sensitive data so it cannot be changed.
+
+If sensitive information needs to be stored on the device itself, several functions/API calls are available to protect the data on the Android device by using the KeyChain and Keystore. The following best practices should therefore be used:
+* Check if a key pair is created within the App by looking for the class KeyPairGenerator.
+* Check that the application is using the KeyStore and Cipher mechanisms to securely store encrypted information on the device. Look for the pattern “import java.security.KeyStore" and “import javax.crypto.Cipher” and it’s usage. Encryption or decryption functions that were self implemented need to be avoided.   
+* The store(OutputStream stream, char[] password) function can be used to store the KeyStore to disk with a specified password. Check that the password provided is not hardcoded and is defined by user input as this should only be known to the user. Look for the pattern “.store(“.
+
+
 
 ### Black-box Testing
 
-[Describe how to test for this issue using static and dynamic analysis techniques. This can include everything from simply monitoring aspects of the app’s behavior to code injection, debugging, instrumentation, etc. ]
+For black box testing, the memory should be analysed in order to be able to retrieve sensitive information, like private keys related to the encryption process. See also OMTG-DATAST-007.
+Check if keys or credentials are logged in log files (OMTG-DATAST-002) or stored permanently unencrypted in the file system (OMTG-DATAST-004). 
+
 
 ### Remediation
 
-[Describe the best practices that developers should follow to prevent this issue]
+The following tasks should be done:
+* Identify keys and passwords in the App, e.g. entered by the users, sent back by the endpoint, shipped within the App and how this sensitive data is processed locally. 
+* Decide (with the developers) if this sensitive stored information locally is needed, and if not if it can be removed or relocated to the endpoint. 
+
+If sensitive information is needed locally on the device several best practices are offered by Android and iOS that should be used to store data securely instead of reinventing the wheel or leave it unencrypted on the device. 
+Username and password should not be stored on the device. Instead, perform initial authentication using the username and password supplied by the user, and then use a short-lived, service-specific authorization token (session token).
+If credentials, keys or other sensitive information need to be stored locally and are only used by one application on the device use the KeyStore to create a keypair and use it for encrypting the information. 
+As a security in depth measure code obfuscation should also be applied to the App, to make reverse engineering harder for attackers. 
+The following is a list of best practice functions used for secure storage of certificates and keys:
+ 
+* KeyStore [3]: The KeyStore provides a secure system level credential storage. It is important to note that the credentials are not actually stored within the KeyStore. An app can create a new private/public key pair to encrypt application secrets by using the public key and decrypt the same by using the private key. The KeyStores is a secure container that makes it difficult for an attacker to retrieve the private key and guards the encrypted data. Nevertheless an attacker can access all keys on a rooted device in the folder /data/misc/keystore/. 	Although the Android Keystore provider was introduced in API level 18 (Android 4.3), the Keystore itself has been available since API 1, restricted to use by VPN and WiFi systems. The Keystore is encrypted using the user’s own lockscreen pin/password, hence, when the device screen is locked the Keystore is unavailable [1].	
+* KeyChain [2]: The KeyChain class is used to store and retrieve private keys and their corresponding certificate (chain). The user will be prompted to set a lock screen PIN or password to protect the credential storage if it hasn’t been set, if something gets imported into the KeyChain the first time.
+
 
 ### References
 
-- [link to relevant how-tos, papers, etc.]
+[1] How to use the Android Keystore to store passwords and other sensitive information  - http://www.androidauthority.com/use-android-keystore-store-passwords-sensitive-information-623779/
+[2] Android KeyChain - http://developer.android.com/reference/android/security/KeyChain.html 
+[3] Android KeyStore System - http://developer.android.com/training/articles/keystore.html
+
+
+
+## <a name="OMTG-DATAST-002"></a>OMTG-DATAST-002: Testing for Sensitive Data Disclosure in Log Files
+
+There are many legit reasons to create log files on a mobile device, for example to keep track of crashes or errors that are stored locally when being offline and being sent to the application developer/company once online again or for usage statistics. However, logging sensitive data such as credit card number and session IDs might expose the data to attackers or malicious applications.
+Log files can be created in various ways on each of the different operating systems. The following table shows the mechanisms that are available on each platform:
+
+| iOS        | Android       | 
+| ------------- |-------------| 
+| NSLog Method      | Log Class, .log[a-Z] | 
+| printf-like function      | Logger Class      |
+| NSAssert-like function | StrictMode     |
+| Macro | System.out / System.err.print    |
+
+### OWASP Mobile Top 10
+M1 - Improper Platform Usage
+M2 - Insecure Data Storage
+
+### CWE 
+CWE-532 - Information Exposure Through Log Files
+CWE-534 - Information Exposure Through Debug Log Files
+
+
+### White-box Testing
+
+Check the source code for usage of Logging functions. 
+
+Decompile the APK to get access to the Java source code as described in <link to guide>
+Import the Java files in an IDE (e.g. IntelliJ or Eclipse) or Editor of your choice or directly open them in JD-Gui, ClassyShark or use grep on the command line to search for
+
+1. Functions like:
+  * Log.d, Log.e, Log.i, Log.v. Log.w or Log.wtf
+  * Logger
+  * System.out.print|System.out.println
+  * StrictMode
+
+2. Keywords (to identify non-standard log mechanisms) like :
+  * Logfile
+  * logging
+
+
+### Black-box Testing
+
+1. Check if log data is generated when starting, using and closing the app by checking application logs, as some mobile applications create and store their own logs. Identify the data directory of the application in order to look for log files (/data/data/package_name). 
+2. Many application developers use still System.out.println() or printStackTrace() instead of a proper logging class. Therefore the testing approach also needs to cover all output generated by the application during starting, running and closing of it and not only the output created by the log classes. In order to verify what data is written to logfiles and printed directly by using System.out.println() or printStackTrace() the code should be checked for these functions and the tool LogCat can be used to check the output. Two different approaches are available to execute LogCat. 
+  * LogCat is already part of Dalvik Debug Monitor Server (DDMS) and is therefore built into Android Studio. Once the app is running and in debug mode, patterns can be defined in LogCat to reduce the log output of the app. 
+  
+![Log output in Android Studio](http://bb-conservation.de/sven/adb.png)
+  
+  
+  * LogCat can be executed by using adb in order to store the log output permanently. 
+
+```
+# adb logcat > logcat.log
+```
+
+
+### Remediation
+
+Ensure logging statements are removed from the production release, as logs may be interrogated or readable by other applications. Tools like ProGuard, which is already included in Android Studio  or DexGuard can be used to strip out logging portions in the code when preparing the production release. For example, to remove logging calls within an android application, we can simply add the following option in the proguard-project.txt configuration file of Proguard:
+
+```
+-assumenosideeffects class android.util.Log
+{
+public static boolean isLoggable(java.lang.String, int);
+public static int v(...);
+public static int i(...);
+public static int w(...);
+public static int d(...);
+public static int e(...);
+}
+```
+
+### References
+
+* Overview of Class Log - http://developer.android.com/reference/android/util/Log.html
+* Debugging Logs with LogCat - http://developer.android.com/tools/debugging/debugging-log.html 
+
+Tools
+* Logcat - http://developer.android.com/tools/help/logcat.html 
+* ProGuard - http://proguard.sourceforge.net/
+* DexGuard - https://www.guardsquare.com/dexguard
+* ClassyShark - https://github.com/google/android-classyshark 
+
+
+
+
+## <a name="OMTG-DATAST-004"></a>OMTG-DATAST-004: Test Sensitive Data Disclosure in Local Stora
+
+Storing data is essential for many mobile applications, for example in order to keep track of user settings or data a user might has keyed in that needs to stored locally or offline. Data can be stored persistently by a mobile application in various ways on each of the different operating systems. The following table shows those mechanisms that are available on each platform:
+
+iOS        | Android       | 
+| ------------- |-------------| 
+| Property lists      | Shared Preferences | 
+| NSKeyedArchiver      | Internal Storage    |
+| NSFileHandle | External Storage     |
+| SQLite Databases | SQLite Databases  |
+| NSUserDefaults |  |
+
+The credo for saving data can be summarized quite easy: Public data should be available for everybody, but sensitive and private data needs to be protected or not stored in the first place on the device itself.  
+This vulnerability can have many consequences, like disclosure of encryption keys that can be used by an attacker to decrypt information. More generally speaking an attacker might be able to identify these information to use it as a basis for other attacks like social engineering (when PII is disclosed), session hijacking (if session information or a token is disclosed) or gather information from apps that have a payment option in order to attack it. 
+
+This vulnerability occurs when sensitive data is not properly protected by an app when persistently storing it. The app might be able to store it in different places, for example locally on the device or on an external SD card. 
+When trying to exploit this kind of issues, consider that there might be a lot of information processed and stored in different locations. It is important to identify at the beginning what kind of information is processed by the mobile application and keyed in by the user and what might be interesting and valuable for an attacker (e.g. passwords, credit card information). 
+
+The following examples shows snippets of code to demonstrate bad practices that discloses sensitive information and also shows the different mechanisms in Android to store data. 
+
+* Shared Preferences
+
+SharedPreferences is a common approach to store Key/Value pairs persistently in the filesystem by using a XML structure. Within an Activity the following code might be used to store sensitive information like a username and a password:
+
+```
+SharedPreferences sharedPref = getSharedPreferences("key", MODE_WORLD_READABLE);
+SharedPreferences.Editor editor = sharedPref.edit();
+editor.putString("username", "administrator");
+editor.putString("password", "supersecret");
+editor.commit();
+```
+
+Once the activity is called, the file key.xml is created with the provided data. This code is violating several best practices. 
+
+  * The username and password is stored in clear text in /data/data/<PackageName>/shared_prefs/key.xml
+
+![Shared Preferences](http://bb-conservation.de/sven/shared_prefs.png)
+
+  * MODE_WORLD_READABLE allows all applications to access and read the content of key.xml
+
+![MODE_WORLD_READABLE](http://bb-conservation.de/sven/mode_world_readable.png)
+
+The usage of Shared Preferences or other mechanisms that are not able to protect data should be avoided to store sensitive information. SharedPreferences are insecure and not encrypted by default. 
+
+* SQLite Databases (Unencrypted)
+
+SQLite is a SQL database that stores data to a text file. The Android SDK comes with built in classes to operate SQLite databases. The main package to manage the databases is android.database.sqlite.
+Within an Activity the following code might be used to store sensitive information like a username and a password:
+SQLiteDatabase notSoSecure = openOrCreateDatabase("privateNotSoSecure",MODE_PRIVATE,null);
+
+```
+notSoSecure.execSQL("CREATE TABLE IF NOT EXISTS Accounts(Username VARCHAR,Password VARCHAR);");
+notSoSecure.execSQL("INSERT INTO Accounts VALUES('admin','AdminPass');");
+notSoSecure.close();
+```
+
+Once the activity is called, the database file privateNotSoSecure is created with the provided data and the data is stored in clear text in /data/data/<PackageName>/databases/privateNotSoSecure.
+There might be several files available in the databases directory, besides the SQLite database.
+  * Journal files: These are temporary files used to implement atomic commit and rollback capabilities in SQLite (see also https://www.sqlite.org/tempfiles.html). 
+  * Lock files: The lock files are part of the locking and journaling mechanism designed to improve concurrency in SQLite and to reduce the writer starvation problem. (https://www.sqlite.org/lockingv3.html) 
+  
+Unencrypted SQLite databases should not be used to store sensitive information. 
+
+* SQLite Databases (Encrypted)
+By using the library SQLCipher SQLite databases can be encrypted, by providing a password. 
+
+SQLiteDatabase secureDB = SQLiteDatabase.openOrCreateDatabase(database, "password123", null);
+
+```
+secureDB.execSQL("CREATE TABLE IF NOT EXISTS Accounts(Username VARCHAR,Password VARCHAR);");
+secureDB.execSQL("INSERT INTO Accounts VALUES('admin','AdminPassEnc');");
+secureDB.close();
+```
+
+If encrypted SQLite databases are used, check if the password is hardcoded in the source, stored in shared preferences or hidden somewhere else in the code or file system. 
+A secure approach to retrieve the key, instead of storing it locally could be to either:
+  * Ask the user every time for a PIN or password to decrypt the database, once the App is opened (weak password or PIN is prone to Brute Force Attacks)
+  * Store the key on the server and make it accessible via a Web Service (then the App can only be used when the device is online)
+
+
+* Internal Storage
+
+Files can be saved directly on the device's internal storage. By default, files saved to the internal storage are private to your application and other applications cannot access them (nor can the user). When the user uninstalls your application, these files are removed [1].
+Within an Activity the following code might be used to store sensitive information in the variable string persistently to the internal storage:
+
+```
+FileOutputStream fos = null;
+fos = openFileOutput(FILENAME, Context.MODE_PRIVATE);
+fos.write(string.getBytes());
+fos.close();
+```
+
+Once the activity is called, the file is created with the provided data and the data is stored in clear text in /data/data/<PackageName>/files/$FILENAME.
+The file mode need to be checked, to make sure that only the app itself has access to the file by using MODE_PRIVATE. Other modes like MODE_WORLD_READABLE and  MODE_WORLD_WRITEABLE are more lax and can pose a security risk. 
+
+It should also be checked what files are read within the App by searching for the usage of class FileInputStream. Part of the internal storage mechanisms is also the cache storage. To cache data temporarily, functions like getCacheDir() can be used. 
+
+* External Storage
+Every Android-compatible device supports a shared "external storage" that you can use to save files. This can be a removable storage media (such as an SD card) or an internal (non-removable) storage. Files saved to the external storage are world-readable and can be modified by the user when they enable USB mass storage to transfer files on a computer [2].
+Within an Activity the following code might be used to store sensitive information in the variable string persistently to the external storage:
+
+```
+           File file = new File (Environment.getExternalStorageDirectory(), "password.txt");
+           String password = "SecretPassword";
+           FileOutputStream fos;
+               fos = new FileOutputStream(file);
+               fos.write(password.getBytes());
+               fos.close();
+```
+
+Once the activity is called, the file is created with the provided data and the data is stored in clear text in the external storage. 
+
+
+### OWASP Mobile Top 10
+M2 - Insecure Data Storage
+
+### CWE 
+CWE-200 - Information Exposure
+
+### White-box Testing
+
+As already pointed out, there are several ways to store information within Android. Several checks should therefore be applied to the source code of an Android App. 
+
+* Check AndroidManifest.xml for permissions to read and write to external storage, like uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE".
+* Check the source code for functions and API calls that are used for storing data and search for:
+  * file permissions like MODE_WORLD_READABLE or MODE_WORLD_WRITABLE. IPC files should not be created with permissions of MODE_WORLD_READABLE or MODE_WORLD_WRITABLE unless it is required as any app would be able to read or write the file even though it may be stored in the app’s private data directory.
+* Check the source code for functions and API calls that are used for storing data and search for Classes and functions like:
+  * Shared Preferences (Storage of key-value pairs)
+  * FileOutPutStream (Using Internal or External Storage)
+  * getExternal* functions (Using External Storage)
+  * getWritableDatabase function (return a SQLiteDatabase for writing)
+  * getReadableDatabase function (return a SQLiteDatabase for reading)
+  * getCacheDir and getExternalCacheDirs function (Using cached files)
+
+### Black-box Testing
+
+Install and use the App as it is intended. Afterwards check the following items: 
+
+* Check the files that are shipped with the mobile application once installed in /data/data/<AppName>/files in order to identify development, backup or simply old files that shouldn’t be in a production release. 
+* Check if .db files are available, which are SQLite databases and if they contain sensitive information (usernames, passwords, keys etc.). SQlite databases can be accessed on the command line with sqlite3. 
+* Check Shared Preferences that are stored as XML files in the shared_prefs directory of the App for sensitive information. 
+* Check the file system permissions of the files in /data/data/<app name>. The permission should only allow rwx to the user and his group that was created for the app (e.g. u0_a82) but not to others. Others should have no permissions to files, but may have the executable flag to directories.
+
+
+### Remediation
+
+Usage of MODE_WORLD_WRITEABLE or MODE_WORLD_READABLE should generally be avoided for files. If data needs to be shared with other applications, a content provider should be considered. A content provider offers read and write permissions to other apps and can make dynamic permission grants on a case-by-case basis. 
+
+Do not use the external storage for sensitive data. By default, files saved to the internal storage are private to your application and other applications cannot access them (nor can the user). When the user uninstalls your application, these files are removed.
+To provide additional protection for sensitive data, you might choose to encrypt local files using a key that is not directly accessible to the application. For example, a key can be placed in a KeyStore and protected with a user password that is not stored on the device. While this does not protect data from a root compromise that can monitor the user inputting the password, it can provide protection for a lost device without file system encryption.
+“secure-preferences” can be used to encrypt the values stored within SharedPrefences [7].
+
+
+### References
+
+* [1] Using Internal Storage - http://developer.android.com/guide/topics/data/data-storage.html#filesInternal 
+* [2] Using External Storage - https://developer.android.com/guide/topics/data/data-storage.html#filesExternal
+* [3] Storing Data - http://developer.android.com/training/articles/security-tips.html#StoringData 
+* [4] Shared Preferences - http://developer.android.com/reference/android/content/SharedPreferences.html 
+* [5] SQLCipher - https://www.zetetic.net/sqlcipher/sqlcipher-for-android/ 
+* [6] Android Keystore - http://developer.android.com/training/articles/keystore.html
+* [7] Secure-Preferences - https://github.com/scottyab/secure-preferences 
+
+Tools
+* Enjarify - https://github.com/google/enjarify 
+* JADX - https://github.com/skylot/jadx
+* Dex2jar - https://github.com/pxb1988/dex2jar 
+* Lint - http://developer.android.com/tools/help/lint.html 
+* SQLite3 - http://www.sqlite.org/cli.html
+
+
+
+
+
+## <a name="OMTG-DATAST-005"></a>OMTG-DATAST-005: Test for sending sensitvie data to 3rd Parties
+
+Different 3rd party services are available that can be embedded into the App to implement different features. This features can vary from tracker services to monitor the user behaviour within the App, selling banner advertisements or to create a better user experience. Interacting with these services abstracts the complexity and neediness to implement the functionality on it’s own and to reinvent the wheel. 
+The downside is that a developer doesn’t know in detail what code is executed via 3rd party libraries and therefore giving up visibility. Consequently it should be ensured that not more information as needed is sent to the service and that no sensitive information is disclosed. 
+3rd party services are mostly implemented in two ways:
+* By using a standalone library, like a Jar in an Android project that is getting included into the APK.
+* By using a full SDK.
+
+Some 3rd party libraries can be automatically integrated into the App through a wizard within the IDE. When talking to developers it should be shared to them that it’s actually necessary to have a look at the diff on the project source code before and after the library was installed through the IDE and what changes have been made to the code base. 
+
+The source code should be checked for API calls or functions provided by the 3rd party library, but also the permissions. It need to be verified that no unnecessary permissions are granted for the 3rd  party library. 
+All requests made  to the external service should be analyzed if any sensitive information is embedded into them. 
+
+### OWASP Mobile Top 10
+M7 - Client Code Quality
+
+### CWE 
+CWE 359 - Exposure of Private Information ('Privacy Violation')
+
+
+### White-box Testing
+
+The permissions set in the AnroidManifest.xml  when installing a library through an IDE wizard should be reviewed. Especially permissions to access SMS (READ_SMS), contacts (ROAD_CONTACTS) or the location (ACCESS_FINE_LOCATION) should be challenged if they are really needed to make the library work at a bare minimum. (See also OMTG-ENV-001).
+
+### Black-box Testing
+
+Dynamic analysis can be performed launching a MITM attack using Burp Proxy, to intercept the traffic exchanged between client and server. Using the certificate provided by Portswigger, Burp can intercept and decrypt the traffic on the fly and manipulate it as you prefer. First of all we need to setup Burp, on our laptop, to listen on a specific port from all the interfaces. After that we can setup the Android device to redirect all the traffic to our laptop, i.e. setting our laptop IP address like proxy.
+A complete guide can be found here (https://support.portswigger.net/customer/portal/articles/1841101-configuring-an-android-device-to-work-with-burp)
+Once we are able to route the traffic to burp, we can try to sniff the traffic from the application. When using the App all requests that are not going directly to the server where the main function is hosted should be checked, if any sensitive information is sent to a 3rd party. This could be for example PII in a tracker or ad service. 
+When decompiling the App, API calls and/or functions provided through the 3rd party library should be reviewed on a source code level to identify if they are used accordingly to best practices. 
+The Jar files loaded into the project should be reviewed in order to identify with the developers if they are needed and also if they are out of date and contain known vulnerabilities.
+
+### Remediation
+
+All data that is sent to 3rd Party services should be anonymized, so no PII data is available. Also all other data, like IDs in an application that can be mapped to a user account or session should not be sent to a third party.  
+AndroidManifest.xml should only contain the permissions that are absolutely needed to work properly and as intended.
+
+### References
+
+* Bulletproof Android, Godfrey Nolan, Chapter 7 - Third-Party Library Integration
+
+
+
+
+## <a name="OMTG-DATAST-006"></a>OMTG-DATAST-006: Test for Sensitive Data Disclosure in Process Memory
+
+Analyzing the memory can help to identify the root cause of different problems, like for example why an application is crashing, but can also be used to identify sensitive data. This section describes how to check for sensitive data and disclosure of data in general within the process memory. 
+
+To be able to investigate the memory of an application a memory dump needs to be created first or the memory needs to be viewed with real-time updates. This is also already the problem, as the application only stores certain information in memory if certain functions are triggered within the application. Memory investigation can of course be executed randomly in every stage of the application, but it is much more beneficial to understand first what the mobile application is doing and what kind of functionalities it offers and also make a deep dive into the decompiled code before making any memory analysis. 
+Once sensitive functions are identified (like decryption of data) the investigation of a memory dump might be beneficial in order to identify sensitive data like a key or decrypted information. 
+
+### OWASP Mobile Top 10
+TBD
+
+### CWE 
+CWE-316 - Cleartext Storage of Sensitive Information in Memory
+
+### White-box Testing
+
+It needs to be identified within the code when sensitive information is stored within a variable and is therefore available within the memory. This information can then be used in dynamic testing when using the App. 
+
+### Black-box Testing
+
+To analyse the memory of an app, the app must be debuggable. See the instructions in XXX on how to repackage and sign an Android App to enable debugging for an app, if not already done. Also ADB integration need to be activated in Android Studio in “Tools/Android/Enable ADB Integration” in order to take a memory dump.
+For rudimentary analysis Android Studio built in tools can be used. Android studio includes tools in the “Android Monitor” tab to investigate the memory. Select the device and app you want to analyse in the "Android Monitor" tab and click on "Dump Java Heap" and a .hprof file will be created. 
+
+![Create Heap Dump](http://bb-conservation.de/sven/mem0.png)
+
+In the new tab that shows the .hprof file, the Package Tree View should be selected. Afterwards the package name of the app can be used to navigate to the instances of classes that were saved in the memory dump. 
+
+![Create Heap Dump](http://bb-conservation.de/sven/mem1.png)
+
+For more deeper analysis of the memory dump Eclipse Memory Analyser (MAT) should be used. The .hprof file will be stored in the directory "captures", relative to the project path open within Android Studio.
+
+Before the hprof file can be opened in MAT the hprof file needs to be converted. The tool hprof-conf can be found in the Android SDK in the directory platform-tools.
+
+```
+./hprof-conv file.hprof file-converted.hprof
+```
+
+By using MAT, more functions are available like usage of the Object Query Language (OQL). OQL is an SQL-like language that can be used to make queries in the memory dump. Analysis should be done on the dominator tree as only this contains the variables/memory of static classes. 
+
+When doing a memory analysis check for sensitive information like:
+* Password and/or Username
+* Decrypted information
+* User or session related information
+* Session ID
+* Interaction with OS, e.g. reading file content
+
+
+### Remediation
+
+If sensitive information is used within the application memory it should be nulled immediately after usage to reduce the attack surface. Information should not be stored in clear text in memory (does this make sense?).
+
+
+### References
+
+* Securely stores sensitive data in RAM - https://www.nowsecure.com/resources/secure-mobile-development/coding-practices/securely-store-sensitive-data-in-ram/
+
+Tools:
+* Android Studio’s Memory Monitor - http://developer.android.com/tools/debugging/debugging-memory.html#ViewHeap 
+* Eclipse’s MAT (Memory Analyzer Tool) standalone - https://eclipse.org/mat/downloads.php 
+* Memory Analyzer which is part of Eclipse - https://www.eclipse.org/downloads/
+* Fridump - http://pentestcorner.com/introduction-to-fridump 
+* Fridump Repo - https://github.com/Nightbringer21/fridump 
+* LiME (formerly DMD) - https://github.com/504ensicsLabs/LiME 
+
+
 
 ## <a name="OMTG-DATAST-009"></a>OMTG-DATAST-009: Test for Sensitive Data in Backups
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Mobile Security Testing Guide
 
-This is the official Github Repository of the OWASP Mobile Application Security Testing Guide [todo].
+This is the official Github Repository of the OWASP Mobile Security Testing Guide [todo].
 
 ## Suggestions and feedback
 
@@ -8,15 +8,9 @@ To report and error or suggest an improvement, please create an [issue](https://
 
 # How to Contribute
 
-The MSTG is an open source effort and we welcome contributions and feedback. If you want to contribute additional content, or improve existing content, we suggest that you first contact us on the OWASP MSTG Slack channel:
-
-https://owasp.slack.com/messages/project-mobile_omtg/details/
-
-You can sign up here:
+The MSTG is an open source effort and we welcome contributions and feedback. Read the [author's guide](https://github.com/b-mueller/owasp-mstg/blob/master/authors_guide.md) first if you want to join our team. To discuss the MASVS or MSTG join the [OWASP Mobile Security Project Slack Channel](https//owasp.slack.com/messages/project-mobile_omtg/details/). You can sign up here:
  
 http://owasp.herokuapp.com/
-
-To add or edit content, simply fork the repository and make your changes, then create a pull request when you are finished. We'll review the changes before we merge them with the master branch in the main repo. In case there's conflicting opinions, we'll create an issue for discussing the changes.
 
 # Read Individual Sections of the MSTG Here
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Mobile Security Testing Guide
 
-This is the official Github Repository of the OWASP Mobile Security Testing Guide [todo].
+This is the official Github Repository of the OWASP Mobile Security Testing Guide (MSTG). The MSTG is a comprehensive manual for testing the security of mobile apps. It describes technical processes for verifying the controls listed in the [OWASP Mobile Application Verification Standard (MASVS)](https://github.com/OWASP/owasp-masvs). The MSTG is meant to provide a baseline set of test cases for black-box and white-box security tests, and to help ensure completeness and consistency of the tests.
 
 ## Suggestions and feedback
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To report and error or suggest an improvement, please create an [issue](https://
 
 # How to Contribute
 
-The MSTG is an open source effort and we welcome contributions and feedback. Read the [author's guide](https://github.com/b-mueller/owasp-mstg/blob/master/authors_guide.md) first if you want to join our team. To discuss the MASVS or MSTG join the [OWASP Mobile Security Project Slack Channel](https//owasp.slack.com/messages/project-mobile_omtg/details/). You can sign up here:
+The MSTG is an open source effort and we welcome contributions and feedback. Read the [author's guide](https://github.com/b-mueller/owasp-mstg/blob/master/authors_guide.md) first if you want to contribute. To discuss the MASVS or MSTG join the [OWASP Mobile Security Project Slack Channel](https//owasp.slack.com/messages/project-mobile_omtg/details/). You can sign up here:
  
 http://owasp.herokuapp.com/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To report and error or suggest an improvement, please create an [issue](https://
 
 # How to Contribute
 
-The MSTG is an open source effort and we welcome contributions and feedback. Read the [author's guide](https://github.com/b-mueller/owasp-mstg/blob/master/authors_guide.md) first if you want to contribute. To discuss the MASVS or MSTG join the [OWASP Mobile Security Project Slack Channel](https//owasp.slack.com/messages/project-mobile_omtg/details/). You can sign up here:
+The MSTG is an open source effort and we welcome contributions and feedback. Read the [author's guide](https://github.com/b-mueller/owasp-mstg/blob/master/authors_guide.md) first if you want to contribute. To discuss the MASVS or MSTG join the [OWASP Mobile Security Project Slack Channel](https://owasp.slack.com/messages/project-mobile_omtg/details/). You can sign up here:
  
 http://owasp.herokuapp.com/
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,25 +1,35 @@
 ## Lead Authors
 
-- OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - Email: frastillavato [at] gmail [dot] com - GitHub: 
-- OMTG-DATAST (Data Storage and Privacy) iOS:
+- Introduction: T.b.d.
 
-- OMTG-CRYPTO (Cryptography) Android: 
-- OMTG-CRYPTO (Cryptography) iOS: 
+- About the OWASP Mobile Testing Guide: T.b.d.
 
-- OMTG-AUTH (Authentication and Session Management) Android:
-- OMTG-AUTH (Authentication and Session Management) iOS:
+- Mobile Platforms Overview - Android: T.b.d.
+- Mobile Platforms Overview - iOS: T.b.d.
 
-- OMTG-NET (Network Communication) Android:
-- OMTG-NET (Network Communication) iOS:
+- Testing Processes and Techniques - Android: T.b.d.
+- Testing Processes and Techniques - iOS: T.b.d.
 
-- OMTG-ENV (Environmental Interaction) Android:
-- OMTG-ENV (Envrionmental Interaction) iOS:
+- OMTG-DATAST (Data Storage and Privacy) - Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
+- OMTG-DATAST (Data Storage and Privacy) - iOS:: T.b.d.
 
-- OMTG-CODE (Code Quality) Android:
-- OMTG-CODE (Code Quality) iOS:
+- OMTG-CRYPTO (Cryptography) - Android: : T.b.d.
+- OMTG-CRYPTO (Cryptography) - iOS:: T.b.d. 
 
-- OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg
-- OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg - GitHub: b-mueller
+- OMTG-AUTH (Authentication and Session Management) - Android:: T.b.d.
+- OMTG-AUTH (Authentication and Session Management) - iOS: T.b.d.
+
+- OMTG-NET (Network Communication) - Android: T.b.d.
+- OMTG-NET (Network Communication) - iOS: T.b.d.
+
+- OMTG-ENV (Environmental Interaction) - Android: T.b.d.
+- OMTG-ENV (Envrionmental Interaction) - iOS: T.b.d.
+
+- OMTG-CODE (Code Quality) - Android: T.b.d.
+- OMTG-CODE (Code Quality) - iOS: T.b.d.
+
+- OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg - GitHub: b-mueller
 
 ## Attribution (authors from Google Doc)
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,10 +1,10 @@
 ## Lead Authors
 
-- OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
+- OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - Email: frastillavato [at] gmail [dot] com - GitHub: 
 - OMTG-DATAST (Data Storage and Privacy) iOS:
 
-- OMTG-RARE (Resiliency Against Reverse Engineering) Android: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
-- OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg - GitHub: b-mueller
 
 ## Attribution (authors from Google Doc)
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,9 +1,12 @@
 ## CHAPTER OWNERS
 
-- OWASP-DATAST Android: Francesco Stillavato
-- OWASP-DATAST iOS:
+- OMTG-DATAST Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
+- OMTG-DATAST iOS:
 
-## Attribution
+- OMTG-RARE Android: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE iOS: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
+
+## Attribution (authors from Google Doc)
 
 ### OMTG-DATAST-009: Test for Sensitive Data in Backups
 

--- a/attribution.md
+++ b/attribution.md
@@ -3,6 +3,21 @@
 - OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - Email: frastillavato [at] gmail [dot] com - GitHub: 
 - OMTG-DATAST (Data Storage and Privacy) iOS:
 
+- OMTG-CRYPTO (Cryptography) Android: 
+- OMTG-CRYPTO (Cryptography) iOS: 
+
+- OMTG-AUTH (Authentication and Session Management) Android:
+- OMTG-AUTH (Authentication and Session Management) iOS:
+
+- OMTG-NET (Network Communication) Android:
+- OMTG-NET (Network Communication) iOS:
+
+- OMTG-ENV (Environmental Interaction) Android:
+- OMTG-ENV (Envrionmental Interaction) iOS:
+
+- OMTG-CODE (Code Quality) Android:
+- OMTG-CODE (Code Quality) iOS:
+
 - OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg
 - OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: [Bernhard Mueller](https://github.com/b-mueller) - Email: bernhard [at] vantagepoint [dot] sg - GitHub: b-mueller
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,4 +1,4 @@
-## CHAPTER OWNERS
+## Lead Authors
 
 - OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
 - OMTG-DATAST (Data Storage and Privacy) iOS:

--- a/attribution.md
+++ b/attribution.md
@@ -10,7 +10,7 @@
 - Testing Processes and Techniques - Android: T.b.d.
 - Testing Processes and Techniques - iOS: T.b.d.
 
-- OMTG-DATAST (Data Storage and Privacy) - Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
+- OMTG-DATAST (Data Storage and Privacy) - Android: Francesco Stillavato - frastillavato [at] gmail [dot] com, Sven Schleier - sven [at] vantagepoint [dot] sg
 - OMTG-DATAST (Data Storage and Privacy) - iOS:: T.b.d.
 
 - OMTG-CRYPTO (Cryptography) - Android: : T.b.d.
@@ -19,13 +19,13 @@
 - OMTG-AUTH (Authentication and Session Management) - Android:: T.b.d.
 - OMTG-AUTH (Authentication and Session Management) - iOS: T.b.d.
 
-- OMTG-NET (Network Communication) - Android: T.b.d.
+- OMTG-NET (Network Communication) - Android: Sven Schleier - sven [at] vantagepoint [dot] sg 
 - OMTG-NET (Network Communication) - iOS: T.b.d.
 
-- OMTG-ENV (Environmental Interaction) - Android: T.b.d.
+- OMTG-ENV (Environmental Interaction) - Android: Sven Schleier - sven [at] vantagepoint [dot] sg 
 - OMTG-ENV (Envrionmental Interaction) - iOS: T.b.d.
 
-- OMTG-CODE (Code Quality) - Android: T.b.d.
+- OMTG-CODE (Code Quality) - Android: T.b.d
 - OMTG-CODE (Code Quality) - iOS: T.b.d.
 
 - OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg

--- a/attribution.md
+++ b/attribution.md
@@ -1,7 +1,7 @@
 ## CHAPTER OWNERS
 
-OWASP-DATAST Android: Francesco Stillavato
-OWASP-DATAST iOS:
+- OWASP-DATAST Android: Francesco Stillavato
+- OWASP-DATAST iOS:
 
 ## Attribution
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,3 +1,11 @@
+== CHAPTER OWNERS ==
+
+OWASP-DATAST Android: Francesco Stillavato
+OWASP-DATAST iOS: Francesco Stillavato
+
+
+== Attribution
+
 === OMTG-DATAST-009: Test for Sensitive Data in Backups
 
 Adapted from MSTG Beta 2:

--- a/attribution.md
+++ b/attribution.md
@@ -10,7 +10,7 @@
 - Testing Processes and Techniques - Android: T.b.d.
 - Testing Processes and Techniques - iOS: T.b.d.
 
-- OMTG-DATAST (Data Storage and Privacy) - Android: Francesco Stillavato - frastillavato [at] gmail [dot] com, Sven Schleier - sven [at] vantagepoint [dot] sg
+- OMTG-DATAST (Data Storage and Privacy) - Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
 - OMTG-DATAST (Data Storage and Privacy) - iOS:: T.b.d.
 
 - OMTG-CRYPTO (Cryptography) - Android: : T.b.d.
@@ -19,13 +19,13 @@
 - OMTG-AUTH (Authentication and Session Management) - Android:: T.b.d.
 - OMTG-AUTH (Authentication and Session Management) - iOS: T.b.d.
 
-- OMTG-NET (Network Communication) - Android: Sven Schleier - sven [at] vantagepoint [dot] sg 
+- OMTG-NET (Network Communication) - Android: T.b.d.
 - OMTG-NET (Network Communication) - iOS: T.b.d.
 
-- OMTG-ENV (Environmental Interaction) - Android: Sven Schleier - sven [at] vantagepoint [dot] sg 
+- OMTG-ENV (Environmental Interaction) - Android: T.b.d.
 - OMTG-ENV (Envrionmental Interaction) - iOS: T.b.d.
 
-- OMTG-CODE (Code Quality) - Android: T.b.d
+- OMTG-CODE (Code Quality) - Android: T.b.d.
 - OMTG-CODE (Code Quality) - iOS: T.b.d.
 
 - OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg

--- a/attribution.md
+++ b/attribution.md
@@ -31,6 +31,12 @@
 - OMTG-RARE (Resiliency Against Reverse Engineering) Android: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg
 - OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: [Bernhard Mueller](https://github.com/b-mueller) - bernhard [at] vantagepoint [dot] sg - GitHub: b-mueller
 
+- Security Tesing in the Application Development Lifecycle: T.b.d.
+
+- Testing Tools: T.b.d.
+
+- Suggested Reading: T.b.d.
+
 ## Attribution (authors from Google Doc)
 
 ### OMTG-DATAST-009: Test for Sensitive Data in Backups

--- a/attribution.md
+++ b/attribution.md
@@ -1,12 +1,11 @@
-== CHAPTER OWNERS ==
+## CHAPTER OWNERS
 
 OWASP-DATAST Android: Francesco Stillavato
-OWASP-DATAST iOS: Francesco Stillavato
+OWASP-DATAST iOS:
 
+## Attribution
 
-== Attribution
-
-=== OMTG-DATAST-009: Test for Sensitive Data in Backups
+### OMTG-DATAST-009: Test for Sensitive Data in Backups
 
 Adapted from MSTG Beta 2:
 

--- a/attribution.md
+++ b/attribution.md
@@ -1,10 +1,10 @@
 ## CHAPTER OWNERS
 
-- OMTG-DATAST Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
-- OMTG-DATAST iOS:
+- OMTG-DATAST (Data Storage and Privacy) Android: Francesco Stillavato - frastillavato [at] gmail [dot] com
+- OMTG-DATAST (Data Storage and Privacy) iOS:
 
-- OMTG-RARE Android: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
-- OMTG-RARE iOS: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE (Resiliency Against Reverse Engineering) Android: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
+- OMTG-RARE (Resiliency Against Reverse Engineering)  iOS: Bernhard Mueller - bernhard [at] vantagepoint [dot] sg
 
 ## Attribution (authors from Google Doc)
 

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -8,7 +8,7 @@ The OWASP MSTG is an open standard, so in principle everyone is welcome to contr
 
 ### Lead author
 
-The lead author takes high-level ownership of a chapter or test case category such as [Testing Sensitive Data Storage on Android](https://github.com/b-mueller/owasp-mstg/blob/master/Document/Testcases/0x00a_OMTG-DATAST_Android.md). A lead author should:
+The lead author takes high-level ownership of a whole chapter or test case category such as [Testing Sensitive Data Storage on Android](https://github.com/b-mueller/owasp-mstg/blob/master/Document/Testcases/0x00a_OMTG-DATAST_Android.md). A lead author should:
 
 1. Contribute an significant amount of quality content to the chapter(s) owned;
 2. Coordinate the work of authors and reviews working on subchapters;
@@ -23,7 +23,7 @@ Lead authors are expected to be highly responsive and actively engage in discuss
 Contributors write content such as single test cases or parts of test cases. For example, a contributor could submit a how-to for testing the custom URL schemes exported by an app. Contributors should:
 
 1. Deliver quality content on the selected topic;
-2. Actively engage with the chapter owners and reviewers via GitHub and Slack.
+2. Actively engage with the chapter owners and reviewers via GitHub and [Slack](https://owasp.slack.com/messages/project-mobile_omtg/details/)
 
 ### Reviewer
 
@@ -31,7 +31,7 @@ Reviewers are subject matter experts that help ensure the quality of the MSTG. A
 
 1. Ensure technical accuracy of the content reviewed;
 2. Check for grammar and spelling errors;
-3. Provide feedback and actively engage with the chapter owners and reviewers via GitHub and Slack.
+3. Provide feedback and actively engage with the chapter owners and reviewers via GitHub and [Slack](https://owasp.slack.com/messages/project-mobile_omtg/details/)
 
 In our experience, opinions will differ in many cases. Whenever differences cannot easily be resolved, open an issue on GitHub and bring it up for discussion. Usually, the open discussion will result in a resolution - if not, the lead author of the chapter in question has the last word.
 

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -8,7 +8,7 @@ The OWASP MSTG is an open standard, so in principle everyone is welcome to contr
 
 ### Lead author
 
-The lead author takes overall ownership of a chapter or group of test cases (such as "Data Storage on Android"). A lead author should:
+The lead author takes high-level ownership of a chapter or test case category such as [Testing Sensitive Data Storage on Android](https://github.com/b-mueller/owasp-mstg/blob/master/Document/Testcases/0x00a_OMTG-DATAST_Android.md). A lead author should:
 
 1. Contribute an significant amount of quality content to the chapter(s) owned;
 2. Coordinate the work of authors and reviews working on subchapters;
@@ -16,7 +16,7 @@ The lead author takes overall ownership of a chapter or group of test cases (suc
 4. Moderate discussions about issues in the chapter(s) owned;
 5. Ensure that milestones for chapter are reached on time.
 
-The lead author is expected to be highly responsive and actively engage in discussions on GitHub and Slack. This requires significant effort, so you should only take up this role if you're sure you can put in the time. 
+Lead authors are expected to be highly responsive and actively engage in discussions on GitHub and [Slack](https://owasp.slack.com/messages/project-mobile_omtg/details/). This requires significant effort, so you should only take up this role if you're sure you can put in the time. 
 
 ### Contributor
 
@@ -45,7 +45,7 @@ Lead authors, contributors and reviewer will be added to the [acknowledgements s
 
 ### Using Content from OWASP MSTG Beta 2
 
-Originally, the OWASP MSTG was developed on Google docs. Lead authors starting on a chapter should check this document first and transfer any usable content into the new version of the guide. Whenever content from the Google Doc is used, the original authors must be credited. Unfortunately, this process can sometimes be painful, but there's no way around it (missing attribution one of the main reason we moved to GitHub). To determine the original authors try the following:
+Originally, the OWASP MSTG was developed on Google Docs. Lead authors starting on a chapter should check this document first and transfer any usable content into the new version of the guide. Whenever content from the [Google Doc](https://docs.google.com/document/d/132Ose0jdQwN6Z_Fp0VOJtVdGCufIwligwmf6oT0lmK8/edit#) is used, the original authors must be credited. Unfortunately, this process can sometimes be painful, but there's no way around it (missing attribution one of the main reason we moved to GitHub). To determine the original authors try the following:
 
 1. Check the owner, authors and reviewers column in the [project plan](http://goo.gl/SsXAvC) (now obsolete);
 2. Check the revision history of the Google doc;
@@ -53,6 +53,8 @@ Originally, the OWASP MSTG was developed on Google docs. Lead authors starting o
 4. If the original author(s) aren't aware of the new MSTG, invite them to join.
 5. Add the content to the new MSTG.
 6. Add the original author(s) to the acknowledgemens and make a note in the attribution document.
+
+Note that content may also originate from the [original "beta" version](https://docs.google.com/document/d/1Z2nCRfe84D3t3IuEm9idX51lh51uzIerFaCV0Z74tbA/edit?ts=56f10e7f).
 
 ## Writing a test case
 

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -1,0 +1,45 @@
+Author's guide
+
+This document contains guidelines for new authors joining the OWASP MSTG. Please read them carefully.
+
+## Roles
+
+Different roles are available for MSTG participants. In principle you can pick any role you want, but note that with great power comes great reponsiblity:
+Once you have taken over a role, you'll be expected to deliver certain results.
+
+### Lead author
+
+The lead author takes overall ownership of a chapter or group of test cases (such as "Data Storage on Android"). A lead author should:
+
+1. Contribute an significant amount of quality content to the chapter(s) owned;
+2. Coordinate the work of authors and reviews working on subchapters;
+3. Manage pull requests for this chapter and ensure the quality of contributions;
+4. Moderate discussions about issues in the chapter(s) owned;
+5. Ensure that milestones for chapter are reached on time.
+
+The lead author should be highly responsive and actively engage in discussions on GitHub and Slack. This requires significant effort, so you should only take up this role if you're sure you can put in the time. 
+
+### Contributor
+
+Contributors write content such as single test cases or parts of test cases. For example, a contributor could submit a how-to for testing the custom URL schemes exported by an app. Contributors should:
+
+1. Deliver quality content on the selected topic;
+2. Actively engage with the chapter owners and reviewers via GitHub and Slack.
+
+### Reviewer
+
+Reviewers are subject matter experts that help ensure the quality of the MSTG. A reviewer will usually pick several chapters and test case groups, and are called upon whenever new content has been added to the selected sections of the MSTG. The reviewer should:
+
+1. Ensure technical accuracy of the content reviewed;
+2. Check for grammar and spelling errors;
+3. Provide feedback and actively engage with the chapter owners and reviewers via GitHub and Slack.
+
+In our experience, opinions will differ in many cases. Whenever differences cannot easily be resolved, open an issue on GitHub and bring it up for discussion. Usually, the open discussion will result in a resolution - if not, the lead author of the chapter in question has the last word.
+
+## Attribution and Acknowledgement
+
+
+### Content from OWASP MSTG Beta 2
+
+
+## Writing a test case

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -4,7 +4,7 @@ This document contains guidelines for new authors joining the OWASP MSTG. Please
 
 ## Picking a Role
 
-Different roles are available for MSTG participants. In principle all roles are available to anyone, but note that with great power comes great reponsiblity. Once you have taken over a role, you'll be expected to deliver certain results.
+The OWASP MSTG is an open standard, so in principle everyone is welcome to contribute or become a chapter owner. We don't check CVs and there is no formal process to go through. That said, keep in mind that with great power comes great reponsiblity: Once you have commited to a role, you'll be expected to deliver quality content.
 
 ### Lead author
 

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -37,11 +37,11 @@ In our experience, opinions will differ in many cases. Whenever differences cann
 
 ## How to become an author
 
-To become a contributor or reviewer, contact the lead author of the respective chapter. 
+To become a contributor or reviewer, contact the lead author of the respective chapter. You can find their name, GitHub handle and email address [here](https://github.com/b-mueller/owasp-mstg/blob/master/attribution.md).
 
 ## Attribution and Acknowledgement
 
-Lead authors, contributors and reviewer are listed in the acknowledgements section of the guide.
+Lead authors, contributors and reviewer will be added to the [acknowledgements section](https://github.com/b-mueller/owasp-mstg/blob/master/Document/0x01-Acknowledgements.md) of the MSTG after their work has been added.
 
 ### Using Content from OWASP MSTG Beta 2
 
@@ -55,3 +55,35 @@ Originally, the OWASP MSTG was developed on Google docs. Lead authors starting o
 6. Add the original author(s) to the acknowledgemens and make a note in the attribution document.
 
 ## Writing a test case
+
+All test cases should follow the following basic guidelines.
+
+### MASVS mapping
+
+The list of test cases in the MSTG maps 1:1 to the requirements in the [OWASP MASVS](https://github.com/OWASP/owasp-masvs). For example, OWASP MASVS V2.9 maps to the test case OMTG-DATAST-009:
+
+- OWASP MASVS V2.9 "Verify that system credential storage facilities are used appropriately to store sensitive data, such as user credentials or cryptographic keys."
+
+-  OMTG-DATAST-009: Test for Sensitive Data in Backups
+
+The MSTG must be kept compatible to the equivalent version of the MASVS. Changes in the list of requirements are always done in the MASVS first, after which the MSTG is updated to match the new requirements.
+
+### Structure of a Test Case
+
+Test cases are split into markdown files by test case category and operating system. For each category, there is a generic list of test cases as well as one file per mobile OS with OS-specific instructions. At the moment, only iOS and Android are discussed in the guide, so there are three files per category.
+
+Use the [test case templates](https://github.com/b-mueller/owasp-mstg/tree/master/Templates) to add a new category.
+
+### Style guide
+
+The following rules are meant to ensure consistency of the MSTG:
+
+1. Keep the content factual, brief and focused. Avoid duplicating other sections of the guide;
+2. Refrain from advertising commercial tools or services;
+3. When giving technical instructions, address the reader in the second person;
+
+Refer to [existing test cases](https://github.com/b-mueller/owasp-mstg/blob/master/Document/Testcases/0x00a_OMTG-DATAST_Android.md#OMTG-DATAST-009) for examples.
+
+### Submitting content
+
+Fork a working copy of the repo to develop your content. Once you are finished editing, submit a pull request. The chapter owner is responsible for reviewing and merging the content.

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -1,11 +1,10 @@
-Author's guide
+# Author's guide
 
 This document contains guidelines for new authors joining the OWASP MSTG. Please read them carefully.
 
-## Roles
+## Picking a Role
 
-Different roles are available for MSTG participants. In principle you can pick any role you want, but note that with great power comes great reponsiblity:
-Once you have taken over a role, you'll be expected to deliver certain results.
+Different roles are available for MSTG participants. In principle all roles are available to anyone, but note that with great power comes great reponsiblity. Once you have taken over a role, you'll be expected to deliver certain results.
 
 ### Lead author
 
@@ -17,7 +16,7 @@ The lead author takes overall ownership of a chapter or group of test cases (suc
 4. Moderate discussions about issues in the chapter(s) owned;
 5. Ensure that milestones for chapter are reached on time.
 
-The lead author should be highly responsive and actively engage in discussions on GitHub and Slack. This requires significant effort, so you should only take up this role if you're sure you can put in the time. 
+The lead author is expected to be highly responsive and actively engage in discussions on GitHub and Slack. This requires significant effort, so you should only take up this role if you're sure you can put in the time. 
 
 ### Contributor
 
@@ -36,10 +35,23 @@ Reviewers are subject matter experts that help ensure the quality of the MSTG. A
 
 In our experience, opinions will differ in many cases. Whenever differences cannot easily be resolved, open an issue on GitHub and bring it up for discussion. Usually, the open discussion will result in a resolution - if not, the lead author of the chapter in question has the last word.
 
+## How to become an author
+
+To become a contributor or reviewer, contact the lead author of the respective chapter. 
+
 ## Attribution and Acknowledgement
 
+Lead authors, contributors and reviewer are listed in the acknowledgements section of the guide.
 
-### Content from OWASP MSTG Beta 2
+### Using Content from OWASP MSTG Beta 2
 
+Originally, the OWASP MSTG was developed on Google docs. Lead authors starting on a chapter should check this document first and transfer any usable content into the new version of the guide. Whenever content from the Google Doc is used, the original authors must be credited. Unfortunately, this process can sometimes be painful, but there's no way around it (missing attribution one of the main reason we moved to GitHub). To determine the original authors try the following:
+
+1. Check the owner, authors and reviewers column in the [project plan](http://goo.gl/SsXAvC) (now obsolete);
+2. Check the revision history of the Google doc;
+3. If you still can't figure it out, ask on the [Slack channel] or on the [mailing list];
+4. If the original author(s) aren't aware of the new MSTG, invite them to join.
+5. Add the content to the new MSTG.
+6. Add the original author(s) to the acknowledgemens and make a note in the attribution document.
 
 ## Writing a test case

--- a/authors_guide.md
+++ b/authors_guide.md
@@ -48,7 +48,7 @@ Lead authors, contributors and reviewer will be added to the [acknowledgements s
 Originally, the OWASP MSTG was developed on Google Docs. Lead authors starting on a chapter should check this document first and transfer any usable content into the new version of the guide. Whenever content from the [Google Doc](https://docs.google.com/document/d/132Ose0jdQwN6Z_Fp0VOJtVdGCufIwligwmf6oT0lmK8/edit#) is used, the original authors must be credited. Unfortunately, this process can sometimes be painful, but there's no way around it (missing attribution one of the main reason we moved to GitHub). To determine the original authors try the following:
 
 1. Check the owner, authors and reviewers column in the [project plan](http://goo.gl/SsXAvC) (now obsolete);
-2. Check the revision history of the Google doc;
+2. Check the revision history of the [Google Doc](https://docs.google.com/document/d/132Ose0jdQwN6Z_Fp0VOJtVdGCufIwligwmf6oT0lmK8/edit#);
 3. If you still can't figure it out, ask on the [Slack channel] or on the [mailing list];
 4. If the original author(s) aren't aware of the new MSTG, invite them to join.
 5. Add the content to the new MSTG.


### PR DESCRIPTION
I migrated the following test cases from the Google Doc:

OMTG-DATAST-001: Testing for Insecure Storage of Credentials and Keys 
OMTG-DATAST-002: Testing for Sensitive Data Disclosure in Log Files 
OMTG-DATAST-004: Testing for Sensitive Data Disclosure in Local Storage
OMTG-DATAST-005: Testing for Sensitive Data sent to 3rd Parties 
OMTG-DATAST-006: Test for Sensitive Data Disclosure in Process Memory
