### PR TITLE
Remove styleguide rule about line length

### DIFF
--- a/style_guide.md
+++ b/style_guide.md
@@ -49,8 +49,8 @@ Link to background information where necessary.
 
 ### Write so people will read with joy!
 
-- Use the following methods to increase scannability:
-- Use shorter (50–80 characters per line) rather than longer line lengths (100 characters per line)
+Use the following methods to increase scannability:
+
 - Use left alignment for headings, subheadings, and text
 - Link where appropriate
 - Use lists rather than paragraphs wherever possible


### PR DESCRIPTION
The line length is not relevant for the rendered version, we don't currently seem to enforce this rule, and it hinders editing.

Currently we have each paragraph on one line. This makes it possible to use the automatic word wrap of your favorite editor. An alternative would be to have newlines in the file to split a paragraph over multiple lines. This would make it easier to read the file in a text editor, but every time you edit the paragraph you would have to do line wrapping again.