### PR TITLE
replace 'fast' by 'fact' in 'the fact is' sentence

### DIFF
--- a/Document/0x03-Overview.md
+++ b/Document/0x03-Overview.md
@@ -46,7 +46,7 @@ All this doesn't mean however that we should let developers get away with writin
 
 ### Anti-Tampering and Anti-Reversing
 
-There are three things you should never bring up in date conversations: Religion, politics and code obfuscation. Many security experts dismiss client-side protections outright. However, the fast is that software protection controls are widely used in the mobile app world, so security testers need ways to deal with them. We also think that there is *some* benefit to be had, as long as the protections are employed with a clear purpose and realistic expectations in mind, and aren't used to *replace* security controls.
+There are three things you should never bring up in date conversations: Religion, politics and code obfuscation. Many security experts dismiss client-side protections outright. However, the fact is that software protection controls are widely used in the mobile app world, so security testers need ways to deal with them. We also think that there is *some* benefit to be had, as long as the protections are employed with a clear purpose and realistic expectations in mind, and aren't used to *replace* security controls.
 
 ## The OWASP Mobile AppSec Verification Standard, Checklist and Testing Guide
 


### PR DESCRIPTION
On the second line of the diff, there is a typo, in "However, the fast is that",
I think you mean "the fact is".

It is just a small fix, but I'd be glad to become an  °˖✧OWASP Contributor✧˖°! 