### PR TITLE
Fix Typo - 0x04e-Testing-Authentication-and-Session-Management

### DIFF
--- a/Document/0x04e-Testing-Authentication-and-Session-Management.md
+++ b/Document/0x04e-Testing-Authentication-and-Session-Management.md
@@ -104,7 +104,7 @@ The secondary authentication can be performed at login or later in the user's se
 
 ##### Transaction Signing with Push Notifications and PKI
 
-Transaction signing requires authentication of the user's approval of critical transactions. Asymmetric cryptography is the best way to implement transaction signing. The app will generate a public/private key pair when the user sigs up, then registers the public key on the back end. The private key is securely stored in the device keystore. To authorize a transaction, the back end sends the mobile app a push notification containing the transaction data. The user is then asked to confirm or deny the transaction. After confirmation, the user is prompted to unlock the Keychain (by entering the PIN or fingerprint), and the data is signed with user's private key. The signed transaction is then sent to the server, which verifies the signature with the user's public key.
+Transaction signing requires authentication of the user's approval of critical transactions. Asymmetric cryptography is the best way to implement transaction signing. The app will generate a public/private key pair when the user signs up, then registers the public key on the back end. The private key is securely stored in the device keystore. To authorize a transaction, the back end sends the mobile app a push notification containing the transaction data. The user is then asked to confirm or deny the transaction. After confirmation, the user is prompted to unlock the Keychain (by entering the PIN or fingerprint), and the data is signed with user's private key. The signed transaction is then sent to the server, which verifies the signature with the user's public key.
 
 ##### Supplementary Schemes
 


### PR DESCRIPTION
"The app will generate a public/private key pair when the user `signs` (was sigs) up, ...."