### PR TITLE
Added frida-server download command

### DIFF
--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -1046,6 +1046,11 @@ $ frida --version
 $ wget https://github.com/frida/frida/releases/download/9.1.10/frida-server-9.1.10-android-arm.xz
 ~~~
 
+Or you can run the following command to automatically detect frida version and download the right frida-server binary:
+
+```bash
+$ wget https://github.com/frida/frida/releases/download/$(frida --version)/frida-server-$(frida --version)-android-arm.xz
+```
 Copy frida-server to the device and run it:
 
 ~~~


### PR DESCRIPTION
The docs shows two different commands: one to find the version and other one to download the frida-server binary after manually updating the version in the url. (As of now the latest frida version downloaded using pypi is: 10.8.2)

I added single bash command `wget https://github.com/frida/frida/releases/download/$(frida --version)/frida-server-$(frida --version)-android-arm.xz` which eases the download of the right binary in single step.