### PR TITLE
Fixed typos in pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@ Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Pl
 
 - [ ] Your contribution is written in the 2nd person (e.g. you)
 - [ ] Your contribution is written in an active present form for as much as possible.
-- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to Mitre/MASVS/etc. are up to date)
+- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
 - [ ] Your contribution has proper formatted markdown and/or code
 - [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
-- [ ] You verified/tested the effectivnes of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
+- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
 
 If your PR is related to an issue. Please end your PR test with the following line:
-This PR coveres issue #<insert number here>.
+This PR covers issue #<insert number here>.


### PR DESCRIPTION
Sorry, this annoyed me ;). Just two small typo's, and MITRE spells itself as uppercase on its website.