### PR TITLE
Add information to allow application installation on a non-iPad device

### DIFF
--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -573,3 +573,26 @@ You can remotely sniff all traffic in real-time on iOS by [creating a Remote Vir
 ```shell
 ip.addr == 192.168.1.1 && http
 ```
+
+### Allow application installation on a non-iPad device
+
+Sometimes an application can require to be used on a iPad device. If you only have iPhone or iPod touch devices then you can force the application to accept to be installed and used on these kinds of devices by changing the value of the property **UIDeviceFamily** to the value **1** in the **Info.plist** file. 
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+  </array>
+
+</dict>
+</plist>  
+```
+
+It is important to note that changing this value will break the original signature of the IPA file so you need to re-sign the IPA, after the update, in order to install it on a device on which the signature validation has not been disabled.
+
+Possible values for the property [UIDeviceFamily](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11 "UIDeviceFamily property").

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -574,7 +574,7 @@ You can remotely sniff all traffic in real-time on iOS by [creating a Remote Vir
 ip.addr == 192.168.1.1 && http
 ```
 
-### Allow application installation on an non-iPad device
+### Allow Application Installation on an Non-Ipad Device
 
 Sometimes an application can require to be used on an iPad device. If you only have iPhone or iPod touch devices then you can force the application to accept to be installed and used on these kinds of devices. You can do this by changing the value of the property **UIDeviceFamily** to the value **1** in the **Info.plist** file. 
 

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -574,9 +574,9 @@ You can remotely sniff all traffic in real-time on iOS by [creating a Remote Vir
 ip.addr == 192.168.1.1 && http
 ```
 
-### Allow application installation on a non-iPad device
+### Allow application installation on an non-iPad device
 
-Sometimes an application can require to be used on a iPad device. If you only have iPhone or iPod touch devices then you can force the application to accept to be installed and used on these kinds of devices by changing the value of the property **UIDeviceFamily** to the value **1** in the **Info.plist** file. 
+Sometimes an application can require to be used on an iPad device. If you only have iPhone or iPod touch devices then you can force the application to accept to be installed and used on these kinds of devices. You can do this by changing the value of the property **UIDeviceFamily** to the value **1** in the **Info.plist** file. 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -593,6 +593,8 @@ Sometimes an application can require to be used on a iPad device. If you only ha
 </plist>  
 ```
 
-It is important to note that changing this value will break the original signature of the IPA file so you need to re-sign the IPA, after the update, in order to install it on a device on which the signature validation has not been disabled.
+It is important to note that changing this value will break the original signature of the IPA file so you need to re-sign the IPA, after the update, in order to install it on a device on which the signature validation has not been disabled. 
+
+This bypass might not work if the application requires capabilities that are specific to iPad device.
 
 Possible values for the property [UIDeviceFamily](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11 "UIDeviceFamily property").

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -595,6 +595,6 @@ Sometimes an application can require to be used on an iPad device. If you only h
 
 It is important to note that changing this value will break the original signature of the IPA file so you need to re-sign the IPA, after the update, in order to install it on a device on which the signature validation has not been disabled. 
 
-This bypass might not work if the application requires capabilities that are specific to iPad device.
+This bypass might not work if the application requires capabilities that are specific to modern iPads while your iphone or iPod is a bit older.
 
 Possible values for the property [UIDeviceFamily](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11 "UIDeviceFamily property").


### PR DESCRIPTION
Hello,

The PR add information to handle the case in which an application require an iPad and the auditor have only iPhone or iPod devices.

Checklist state:
- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

Thanks you very much in advance.
