### PR TITLE
Add Magisk manager package name to list

### DIFF
--- a/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -140,6 +140,7 @@ com.noshufou.android.su
 com.koushikdutta.superuser
 com.zachspong.temprootremovejb
 com.ramdroid.appquarantine
+com.topjohnwu.magisk
 ```
 
 **Checking for writable partitions and system directories**


### PR DESCRIPTION
This commit adds Magisk manager package to the list of popular Android rooting tools.
