### PR TITLE
Fix markdown for code chunks

### DIFF
--- a/Document/0x04e-Testing-Authentication-and-Session-Management.md
+++ b/Document/0x04e-Testing-Authentication-and-Session-Management.md
@@ -284,19 +284,19 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4
 
 The *header* typically consists of two parts: the token type, which is JWT, and the hashing algorithm being used to compute the signature. In the example above, the header decodes as follows:
 
-```
+```json
 {"alg":"HS256","typ":"JWT"}
 ```
 
 The second part of the token is the *payload*, which contains so-called claims. Claims are statements about an entity (typically, the user) and additional metadata. For example:
 
-```
+```json
 {"sub":"1234567890","name":"John Doe","admin":true}
 ```
 
 The signature is created by applying the algorithm specified in the JWT header to the encoded header, encoded payload, and a secret value. For example, when using the HMAC SHA256 algorithm the signature is created in the following way:
 
-```
+```java
 HMACSHA256(base64UrlEncode(header) + "." + base64UrlEncode(payload), secret)
 ```
 

--- a/Document/0x04f-Testing-Network-Communication.md
+++ b/Document/0x04f-Testing-Network-Communication.md
@@ -54,9 +54,9 @@ $ brew install ettercap
 Ettercap can also be installed through `apt-get` on Debian based linux distributions.
 
 ```shell
-sudo apt-get install zlib1g zlib1g-dev
-sudo apt-get install build-essential
-sudo apt-get install ettercap
+$ sudo apt-get install zlib1g zlib1g-dev
+$ sudo apt-get install build-essential
+$ sudo apt-get install ettercap
 ```
 
 **Network Analyzer Tool**
@@ -157,7 +157,7 @@ When testing a Xamarin app and when you are trying to set the system proxy in th
 
 - Add a [default proxy to the app](https://developer.xamarin.com/api/type/System.Net.WebProxy/ "System.Net.WebProxy Class"), by adding the following code in the `OnCreate()` or `Main()` method and re-create the app:
 
-```
+```csharp
 WebRequest.DefaultWebProxy = new WebProxy("192.168.11.1", 8080);
 ```
 

--- a/Document/0x04h-Testing-Code-Quality.md
+++ b/Document/0x04h-Testing-Code-Quality.md
@@ -246,12 +246,12 @@ Sergey Bobrov was able to take advantage of this in the following [HackerOne rep
 
 - ADB
 ```shell
-adb shell
-am start -n com.quora.android/com.quora.android.ActionBarContentActivity -e url 'http://test/test' -e html 'XSS<script>alert(123)</script>'
+$ adb shell
+$ am start -n com.quora.android/com.quora.android.ActionBarContentActivity -e url 'http://test/test' -e html 'XSS<script>alert(123)</script>'
 ```
 - Clipboard Data
 ```shell
-am start -n com.quora.android/com.quora.android.ModalContentActivity -e url 'http://test/test' -e html '<script>alert(QuoraAndroid.getClipboardData());</script>'
+$ am start -n com.quora.android/com.quora.android.ModalContentActivity -e url 'http://test/test' -e html '<script>alert(QuoraAndroid.getClipboardData());</script>'
 ```
 - 3rd party Intent
 

--- a/Document/0x04h-Testing-Code-Quality.md
+++ b/Document/0x04h-Testing-Code-Quality.md
@@ -18,7 +18,7 @@ A *SQL injection* attack involves integrating SQL commands into input data, mimi
 
 Apps on both Android and iOS use SQLite databases as a means to control and organize local data storage. Assume an Android app handles local user authentication by storing the user credentials in a local database (a poor programming practice we’ll overlook for the sake of this example). Upon login, the app queries the database to search for a record with the username and password entered by the user:
 
-```java=
+```java
 SQLiteDatabase db;
 
 String sql = "SELECT * FROM users WHERE username = '" +  username + "' AND password = '" + password +"'";
@@ -46,7 +46,7 @@ Because the condition `'1' = '1'` always evaluates as true, this query return al
 
 Ostorlab exploited the sort parameter of Yahoo's weather mobile application with adb using this SQL injection payload.
 
-```
+```shell
 $ adb shell content query --uri content://com.yahoo.mobile.client.android.weather.provider.Weather/locations/ --sort '_id/**/limit/**/\(select/**/1/**/from/**/sqlite_master/**/where/**/1=1\)'  
 
 Row: 0 _id=1, woeid=2487956, isCurrentLocation=0, latitude=NULL, longitude=NULL, photoWoeid=NULL, city=NULL, state=NULL, stateAbbr=, country=NULL, countryAbbr=, timeZoneId=NULL, timeZoneAbbr=NULL, lastUpdatedTimeMillis=746034814, crc=1591594725
@@ -58,7 +58,6 @@ The payload can be further simplified using the following `_id/**/limit/**/\(sel
 This SQL injection vulnerability did not expose any sensitive data that the user didn't already have access to. This example presents a way that adb can be used to test vulnerable content providers. Ostorlab takes this even further and creates a webpage instance of the SQLite query, then runs SQLmap to dump the tables.
 
 ```python
-
 import subprocess
 from flask import Flask, request
 
@@ -84,7 +83,6 @@ def hello():
 
 if __name__=="__main__":
    app.run()
-
 ```
 
 One real-world instance of client-side SQL injection was discovered by Mark Woods within the "Qnotes" and "Qget" Android apps running on QNAP NAS storage appliances. These apps exported content providers vulnerable to SQL injection, allowing an attacker to retrieve the credentials for the NAS device. A detailed description of this issue can be found on the [Nettitude Blog](https://blog.nettitude.com/uk/qnap-android-dont-provide "Nettitude Blog - QNAP Android: Don't Over Provide").

--- a/Document/0x05a-Platform-Overview.md
+++ b/Document/0x05a-Platform-Overview.md
@@ -38,7 +38,7 @@ The file [system/core/include/private/android_filesystem_config.h](http://androi
 
 For example, Android Nougat defines the following system users:
 
-```
+```c
     #define AID_ROOT             0  /* traditional unix root user */
 
     #define AID_SYSTEM        1000  /* system server */
@@ -86,7 +86,7 @@ Installed Android apps are located at `/data/app/[package-name]`. For example, t
 
 The Android Package Kit (APK) file is an archive that contains the code and resources required to run the app it comes with. This file is identical to the original, signed app package created by the developer. It is in fact a ZIP archive with the following directory structure:
 
-```
+```shell
 $ unzip base.apk
 $ ls -lah
 -rw-r--r--   1 sven  staff    11K Dec  5 14:45 AndroidManifest.xml
@@ -175,13 +175,13 @@ drwxrwx--x u0_a65   u0_a65            2016-01-10 09:44 shared_prefs
 Android leverages Linux user management to isolate apps. This approach is different from user management usage in traditional Linux environments, where multiple apps are often run by the same user. Android creates a unique UID for each Android app and runs the app in a separate process. Consequently, each app can access its own resources only. This protection is enforced by the Linux kernel.
 
 Generally, apps are assigned UIDs in the range of 10000 and 99999. Android apps receive a user name based on their UID. For example, the app with UID 10188 receives the user name `u0_a188`. If the permissions an app requested are granted, the corresponding group ID is added to the app's process. For example, the user ID of the app below is 10188. It belongs to the group ID 3003 (inet). That group is related to android.permission.INTERNET permission. The output of the `id` command is shown below.
-```
+```shell
 $ id
 uid=10188(u0_a188) gid=10188(u0_a188) groups=10188(u0_a188),3003(inet),9997(everybody),50188(all_a188) context=u:r:untrusted_app:s0:c512,c768
 ```
 
 The relationship between group IDs and permissions is defined in the file [frameworks/base/data/etc/platform.xml](http://androidxref.com/7.1.1_r6/xref/frameworks/base/data/etc/platform.xml)
-```
+```xml
 <permission name="android.permission.INTERNET" >
 	<group gid="inet" />
 </permission>
@@ -206,14 +206,14 @@ Installation of a new app creates a new directory named after the app package, w
 
 We can confirm this by looking at the file system permissions in the `/data/data` folder. For example, we can see that Google Chrome and Calendar are assigned one directory each and run under different user accounts:
 
-```
+```shell
 drwx------  4 u0_a97              u0_a97              4096 2017-01-18 14:27 com.android.calendar
 drwx------  6 u0_a120             u0_a120             4096 2017-01-19 12:54 com.android.chrome
 ```
 
 Developers who want their apps to share a common sandbox can sidestep sandboxing . When two apps are signed with the same certificate and explicitly share the same user ID (having the _sharedUserId_ in their _AndroidManifest.xml_ files), each can access the other's data directory. See the following example to achieve this in the NFC app:
 
-```
+```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.android.nfc"
   android:sharedUserId="android.uid.nfc">
@@ -241,7 +241,7 @@ Every app has a manifest file, which embeds content in binary XML format. The st
 The manifest file describes the app structure, its components (activities, services, content providers, and intent receivers), and requested permissions. It also contains general app metadata, such as the app's  icon, version number, and theme. The file may list other information,  such as compatible APIs (minimal, targeted, and maximal SDK version) and the [kind of storage it can be installed on (external or internal)](https://developer.android.com/guide/topics/data/install-location.html "Define app install location").
 
 Here is an example of a manifest file, including the package name (the convention is a reversed  URL, but any string is acceptable). It also lists the app version, relevant SDKs, required permissions, exposed content providers, broadcast receivers used with intent filters, and a description of the app and its activities:
-```
+```xml
 <manifest
 	package="com.owasp.myapplication"
 	android:versionCode="0.1" >
@@ -296,7 +296,7 @@ Activities make up the visible part of any app. There is one activity per screen
 
 Each activity needs to be declared in the app manifest with the following syntax:
 
-```
+```xml
 <activity android:name="ActivityName">
 </activity>
 ```
@@ -367,7 +367,7 @@ Services that allow other applications to bind to them are called *bound service
 
 Servicemanager is a system daemon that manages the registration and lookup of system services. It maintains a list of name/Binder pairs for all registered services. Services are added with `addService` and retrieved by name with the static `getService` method in `android.os.ServiceManager`:
 
-```
+```java
   public static IBinder getService(String name)
 ```
 
@@ -426,7 +426,7 @@ Broadcast Receivers are components that allow apps to receive notifications from
 Broadcast Receivers must be declared in the app's manifest file. The manifest must specify an association between the Broadcast Receiver and an intent filter to indicate the actions the receiver is meant to listen for. If Broadcast Receivers aren't declared, the app won't listen to broadcasted messages. However, apps don’t need to be running to receive intents; the system starts apps automatically when a relevant intent is raised.
 
 An example Broadcast Receiver declaration with an intent filter in a manifest:
-```
+```xml
 	<receiver android:name=".myReceiver" >
 		<intent-filter>
 			<action android:name="com.owasp.myapplication.MY_ACTION" />
@@ -474,7 +474,7 @@ Example: `android.permission.ACCESS_DOWNLOAD_MANAGER`
 
 Apps can request permissions for the protection levels Normal, Dangerous, and Signature by including `<uses-permission />` tags  into their manifest.
 The example below shows an AndroidManifest.xml sample requesting permission to read SMS messages:
-```
+```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.permissions.sample" ...>
 
@@ -487,7 +487,7 @@ The example below shows an AndroidManifest.xml sample requesting permission to r
 
 Apps can expose features and content to other apps installed on the system. To restrict access to its own components, it can either use any of Android’s [predefined permissions](https://developer.android.com/reference/android/Manifest.permission.html)  or define its own. A new permission is declared with the <permission>element.
 The example below shows an app declaring a permission:
-```
+```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.permissions.sample" ...>
 
@@ -503,7 +503,7 @@ The above code defines a new permission named `com.permissions.sample.ACCESS_USE
 
 Android components can be protected with permissions. Activities, Services, Content Providers, and Broadcast Receivers—all can use the permission mechanism to protect their interfaces.
 Permissions can be enforced on *Activities*, *Services*, and *Broadcast Receivers* by adding the attribute *android:permission* to the respective component tag in AndroidManifest.xml:
-```
+```xml
 <receiver
     android:name="com.permissions.sample.AnalyticsReceiver"
     android:enabled="true"
@@ -545,8 +545,8 @@ With the APK signature scheme, the complete APK is hashed and signed, and an APK
 Android uses public/private certificates to sign Android apps (.apk files). Certificates are bundles of information; in terms of security, keys are the most important type of this information Public certificates contain users' public keys, and private certificates contain users' private keys. Public and private certificates are linked. Certificates are unique and can't be re-generated. Note that if a certificate is lost, it cannot be recovered, so updating any apps signed with that certificate becomes impossible.
 App creators can either reuse an existing private/public key pair that is in an available keystore or generate a new pair.
 In the Android SDK, a new key pair is generated with the `keytool` command. The following command creates a RSA key pair with a key length of 2048 bits and an expiry time of 7300 days = 20 years. The generated key pair is stored in the file 'myKeyStore.jks', which is in the current directory):
-```
-keytool -genkey -alias myDomain -keyalg RSA -keysize 2048 -validity 7300 -keystore myKeyStore.jks -storepass myStrongPassword
+```shell
+$ keytool -genkey -alias myDomain -keyalg RSA -keysize 2048 -validity 7300 -keystore myKeyStore.jks -storepass myStrongPassword
 ```
 
 Safely storing your secret key and making sure it remains secret during its entire lifecycle is of paramount importance. Anyone who gains access to the key will be able to publish updates to your apps with content that you don't control (thereby adding insecure features or accessing shared content with signature-based permissions). The trust that a user places in an app and its developers is based totally on such certificates; certificate protection and secure management are therefore vital for reputation and customer retention, and secret keys must never be shared with other individuals. Keys are stored in a binary file that can be protected with a password; such files are referred to as 'keystores'. Keystore passwords should be strong and known only to the key creator. For this reason, keys are usually stored on a dedicated build machine that developers have limited access to.
@@ -558,8 +558,8 @@ The goal of the signing process is to associate the app file (.apk) with the dev
 
 Many Integrated Development Environments (IDE) integrate the app signing process to make it easier for the user. Be aware that some IDEs store private keys in clear text in configuration files; double-check this in case others are able to access such files and remove the information if necessary.
 Apps can be signed from the command line with the 'apksigner' tool provided by the Android SDK (API 24 and higher). It is located at `[SDK-Path]/build-tools/[version]`. For API 24.0.2 and below, you can use 'jarsigner', which is part of the Java JDK. Details about the whole process can be found in official Android documentation; however, an example is given below to illustrate the point.
-```
-apksigner sign --out mySignedApp.apk --ks myKeyStore.jks myUnsignedApp.apk
+```shell 
+$ apksigner sign --out mySignedApp.apk --ks myKeyStore.jks myUnsignedApp.apk
 ```
 In this example, an unsigned app ('myUnsignedApp.apk') will be signed with a private key from the developer keystore 'myKeyStore.jks' (located in the current directory). The app will become a signed app called 'mySignedApp.apk' and will be ready to release to stores.
 

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -168,7 +168,7 @@ $ adb pull /data/app/com.awesomeproject-1/base.apk
 
 `apkx` provides an easy method of retrieving an APK's source code via the command line. It also packages `dex2jar` and CFR and automates the extraction, conversion, and decompilation steps. Install it as follows:
 
-```
+```shell
 $ git clone https://github.com/b-mueller/apkx
 $ cd apkx
 $ sudo ./install.sh
@@ -456,20 +456,20 @@ Start the app and trigger a function that uses FCM. You should see HTTP messages
 
 Pre-built packages for many Linux distributions are available on the [Drozer website](https://labs.mwrinfosecurity.com/tools/drozer/ "Drozer Website"). If your distribution is not listed, you can build Drozer from source as follows:
 
-```
-git clone https://github.com/mwrlabs/drozer/
-cd drozer
-make apks
-source ENVIRONMENT
-python setup.py build
-sudo env "PYTHONPATH=$PYTHONPATH:$(pwd)/src" python setup.py install
+```shell
+$ git clone https://github.com/mwrlabs/drozer/
+$ cd drozer
+$ make apks
+$ source ENVIRONMENT
+$ python setup.py build
+$ sudo env "PYTHONPATH=$PYTHONPATH:$(pwd)/src" python setup.py install
 ```
 
 **On Mac:**
 
 On Mac, Drozer is a bit more difficult to install due to missing dependencies. Mac OS versions from El Capitan onwards don't have OpenSSL installed, so compiling pyOpenSSL won't work. You can resolve this issue by [installing OpenSSL manually]. To install openSSL, run:
 
-```
+```shell
 $ brew install openssl
 ```
 
@@ -477,13 +477,13 @@ Drozer depends on older versions of some libraries. Avoid messing up the system'
 
 Install virtualenv via pip:
 
-```
+```shell 
 $ pip install virtualenv
 ```
 
 Create a project directory to work in; you'll download several files into it. Navigate into the newly created directory and run the command `virtualenv drozer`. This creates a "drozer" folder, which contains the Python executable files and a copy of the pip library.
 
-```
+```shell
 $ virtualenv drozer
 $ source drozer/bin/activate
 (drozer) $
@@ -492,7 +492,7 @@ $ source drozer/bin/activate
 You're now ready to install the required version of pyOpenSSL and build it against the OpenSSL headers installed previously. A typo in the source of the pyOpenSSL version Drozer prevents successful compilation, so you'll need to fix the source before compiling. Fortunately, ropnop has figured out the necessary steps and documented them in a [blog post](https://blog.ropnop.com/installing-drozer-on-os-x-el-capitan/ "ropnop Blog - Installing Drozer on OS X El Capitan").
 Run the following commands:
 
-```
+```shell
 $ wget https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.13.tar.gz
 $ tar xzvf pyOpenSSL-0.13.tar.gz
 $ cd pyOpenSSL-0.13
@@ -504,13 +504,13 @@ $ python setup.py install
 
 With that out of the way, you can install the remaining dependencies.
 
-```
+```shell
 $ easy_install protobuf==2.4.1 twisted==10.2.0
 ```
 
 Finally, download and install the Python .egg from the MWR labs website:
 
-```
+```shell 
 $ wget https://github.com/mwrlabs/drozer/releases/download/2.3.4/drozer-2.3.4.tar.gz
 $ tar xzf drozer-2.3.4.tar.gz
 $ easy_install drozer-2.3.4-py2.7.egg
@@ -520,7 +520,7 @@ $ easy_install drozer-2.3.4-py2.7.egg
 
 Drozer agent is the software component that runs on the device itself. Download the latest Drozer Agent [here](https://github.com/mwrlabs/drozer/releases/) and install it with adb.
 
-```
+```shell
 $ adb install drozer.apk
 ```
 

--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -123,7 +123,7 @@ Reverse engineering is the process of taking an app apart to find out how it wor
 
 Java bytecode can be converted back into source code without many problems unless some nasty, tool-breaking anti-decompilation tricks have been applied. We'll be using UnCrackable App for Android Level 1 in the following examples, so download it if you haven't already. First, let's install the app on a device or emulator and run it to see what the crackme is about.
 
-```
+```shell
 $ wget https://github.com/OWASP/owasp-mstg/raw/master/Crackmes/Android/Level_01/UnCrackable-Level1.apk
 $ adb install UnCrackable-Level1.apk
 ```
@@ -134,7 +134,7 @@ Seems like we're expected to find some kind of secret code!
 
 We're looking for a secret string stored somewhere inside the app, so the next step is to look inside. First, unzip the APK file and look at the content.
 
-```
+```shell
 $ unzip UnCrackable-Level1.apk -d UnCrackable-Level1
 Archive:  UnCrackable-Level1.apk
   inflating: UnCrackable-Level1/AndroidManifest.xml  
@@ -159,7 +159,7 @@ Once you have a JAR file, you can use any free decompiler to produce Java code. 
 
 The easiest way to run CFR is through `apkx`, which also packages `dex2jar` and automates extraction, conversion, and decompilation. Install it:
 
-```
+```shell
 $ git clone https://github.com/b-mueller/apkx
 $ cd apkx
 $ sudo ./install.sh
@@ -305,7 +305,7 @@ So where is the native implementation of this function? If you look into the `li
 
 Following the naming convention mentioned above, you can expect the library to export a symbol called `Java_sg_vantagepoint_helloworld_MainActivity_stringFromJNI`. On Linux systems, you can retrieve the list of symbols with `readelf` (included in GNU binutils) or `nm`. Do this on Mac OS with the `greadelf` tool, which you can install via Macports or Homebrew. The following example uses `greadelf`:
 
-```
+```shell
 $ greadelf -W -s libnative-lib.so | grep Java
      3: 00004e49   112 FUNC    GLOBAL DEFAULT   11 Java_sg_vantagepoint_helloworld_MainActivity_stringFromJNI
 ```
@@ -336,37 +336,37 @@ Not a lot of code there, but you should analyze it. The first thing you need to 
 
 With that in mind, let's have a look at each line of assembly code.
 
-```
+```arm
 LDR  R2, [R0]
 ```
 
 Remember: the first argument (in R0) is a pointer to the JNI function table pointer. The `LDR` instruction loads this function table pointer into R2.
 
-```
+```arm
 LDR  R1, =aHelloFromC
 ```
 
 This instruction loads into R1 the pc-relative offset of the string "Hello from C++." Note that this string comes directly after the end of the function block at offset 0xe84. Addressing relative to the program counter allows the code to run independently of its position in memory.
 
-```
+```arm
 LDR.W  R2, [R2, #0x29C]
 ```
 
 This instruction loads the function pointer from offset 0x29C into the JNI function pointer table pointed to by R2. This is the `NewStringUTF` function. You can look at the list of function pointers in jni.h, which is included in the Android NDK. The function prototype looks like this:
 
-```
+```c
 jstring     (*NewStringUTF)(JNIEnv*, const char*);
 ```
 
 The function takes two arguments: the JNIEnv pointer (already in R0) and a String pointer. Next, the current value of PC is added to R1, resulting in the absolute address of the static string "Hello from C++" (PC + offset).
 
-```
+```arm
 ADD  R1, PC
 ```
 
 Finally, the program executes a branch instruction to the `NewStringUTF` function pointer loaded into R2:
 
-```
+```arm
 BX   R2
 ```
 
@@ -398,7 +398,7 @@ To re-sign, you first need a code-signing certificate. If you have built a proje
 
 The standard Java distribution includes `keytool` for managing keystores and certificates. You can create your own signing certificate and key, then add it to the debug keystore:
 
-```
+```shell
 $ keytool -genkey -v -keystore ~/.android/debug.keystore -alias signkey -keyalg RSA -keysize 2048 -validity 20000
 ```
 
@@ -866,10 +866,10 @@ All of this makes it possible to build tracers that are practically transparent 
 
 PANDA comes with pre-made plugins, including a stringsearch tool and a syscall tracer. Most importantly, it supports Android guests, and some of the DroidScope code has even been ported. Building and running PANDA for Android ("PANDROID") is relatively straightforward. To test it, clone Moiyx's git repository and build PANDA:
 
-~~~
+```shell
 $ cd qemu
 $ ./configure --target-list=arm-softmmu --enable-android $ makee
-~~~
+```
 
 As of this writing, Android versions up to 4.4.1 run fine in PANDROID, but anything newer than that won't boot. Also, the Java level introspection code only works on the Android 2.3 Dalvik runtime. Older versions of Android seem to run much faster in the emulator, so sticking with Gingerbread is probably best if you plan to use PANDA. For more information, check out the extensive documentation in the PANDA git repo.
 
@@ -1038,11 +1038,11 @@ $ sudo pip install frida
 
 Your Android device doesn't need to be rooted to run Frida, but it's the easiest setup. We assume a rooted device here unless otherwise noted. Download the frida-server binary from the [Frida releases page](https://github.com/frida/frida/releases). Make sure that you download the right frida-server binary for the architecture of your Android device or emulator: x86, x86_64, arm or arm64. Make sure that the server version (at least the major version number) matches the version of your local Frida installation. PyPI usually installs the latest version of Frida. If you're unsure which version is installed, you can check with the Frida command line tool:
 
-~~~
+```shell
 $ frida --version
 9.1.10
 $ wget https://github.com/frida/frida/releases/download/9.1.10/frida-server-9.1.10-android-arm.xz
-~~~
+```
 
 Or you can run the following command to automatically detect frida version and download the right frida-server binary:
 
@@ -1051,15 +1051,15 @@ $ wget https://github.com/frida/frida/releases/download/$(frida --version)/frida
 ```
 Copy frida-server to the device and run it:
 
-~~~
+```shell
 $ adb push frida-server /data/local/tmp/
 $ adb shell "chmod 755 /data/local/tmp/frida-server"
 $ adb shell "su -c /data/local/tmp/frida-server &"
-~~~
+```
 
 With frida-server running, you should now be able to get a list of running processes with the following command:
 
-~~~
+```shell
 $ frida-ps -U
   PID  Name
 -----  --------------------------------------------------------------
@@ -1071,33 +1071,33 @@ $ frida-ps -U
  5353  com.android.settings
   936  com.android.systemui
 (...)
-~~~
+```
 
 The -U option lets Frida search for USB devices or emulators.
 
 To trace specific (low-level) library calls, you can use the `frida-trace` command line tool:
 
-~~~
+```shell
 frida-trace -i "open" -U com.android.chrome
-~~~
+```
 
 This generates a little JavaScript in `__handlers__/libc.so/open.js`, which Frida injects into the process. The script traces all calls to the `open` function in `libc.so`. You can modify the generated script according to your needs with Frida [JavaScript API](https://www.frida.re/docs/javascript-api/).
 
 Use `frida CLI` to work with Frida interactively. It hooks into a process and gives you a command line interface to Frida's API.
 
-~~~
+```shell
 frida -U com.android.chrome
-~~~
+```
 
 With the `-l` option, you can also use the Frida CLI to load scripts , e.g., to load `myscript.js`:
 
-~~~
+```shell
 frida -U -l myscript.js com.android.chrome
-~~~
+```
 
 Frida also provides a Java API, which is especially helpful for dealing with Android apps. It lets you work with Java classes and objects directly. Here is a script to overwrite the `onResume` function of an Activity class:
 
-~~~
+```java
 Java.perform(function () {
     var Activity = Java.use("android.app.Activity");
     Activity.onResume.implementation = function () {
@@ -1105,13 +1105,13 @@ Java.perform(function () {
         this.onResume();
     };
 });
-~~~
+```
 
 The above script calls `Java.perform` to make sure that your code gets executed in the context of the Java VM. It instantiates a wrapper for the `android.app.Activity` class via `Java.use` and overwrites the `onResume()` function. The new `onResume()` function implementation prints a notice to the console and calls the original `onResume()` method by invoking `this.onResume()` every time an activity is resumed in the app.
 
 Frida also lets you search for and work with instantiated objects that are on the heap. The following script searches for instances of `android.view.View` objects and calls their `toString` method. The result is printed to the console:
 
-~~~
+```java
 setImmediate(function() {
     console.log("[*] Starting script");
     Java.perform(function () {
@@ -1125,22 +1125,22 @@ setImmediate(function() {
         });
     });
 });
-~~~
+```
 
 The output would look like this:
 
-~~~
+```
 [*] Starting script
 [*] Instance found: android.view.View{7ccea78 G.ED..... ......ID 0,0-0,0 #7f0c01fc app:id/action_bar_black_background}
 [*] Instance found: android.view.View{2809551 V.ED..... ........ 0,1731-0,1731 #7f0c01ff app:id/menu_anchor_stub}
 [*] Instance found: android.view.View{be471b6 G.ED..... ......I. 0,0-0,0 #7f0c01f5 app:id/location_bar_verbose_status_separator}
 [*] Instance found: android.view.View{3ae0eb7 V.ED..... ........ 0,0-1080,63 #102002f android:id/statusBarBackground}
 [*] Finished heap search
-~~~
+```
 
 You can also use Java's reflection capabilities. To list the public methods of the `android.view.View` class, you could create a wrapper for this class in Frida and call `getMethods()` from the wrapper's `class` property:
 
-~~~
+```java
 Java.perform(function () {
     var view = Java.use("android.view.View");
     var methods = view.class.getMethods();
@@ -1148,7 +1148,7 @@ Java.perform(function () {
         console.log(methods[i].toString());
     }
 });
-~~~
+```
 
 Frida also provides bindings for various languages, including Python, C, NodeJS, and Swift.
 
@@ -1163,7 +1163,7 @@ When you start the App on an emulator or a rooted device, you'll find that the a
 Let's see how we can prevent this.
 The main method (decompiled with CFR) looks like this:
 
-```
+```java
 package sg.vantagepoint.uncrackable1;
 
 import android.app.Activity;
@@ -1219,7 +1219,7 @@ Notice the "Root detected" message in the `onCreate` method and the various meth
 
 The `onClickListener` implementation for the dialog button doesn't do much:
 
-```
+```java
 package sg.vantagepoint.uncrackable1;
 
 class b implements android.content.DialogInterface$OnClickListener {
@@ -1240,7 +1240,7 @@ class b implements android.content.DialogInterface$OnClickListener {
 
 It just exits the app. Now intercept it with Frida to prevent the app from exiting after root detection:
 
-```
+```java
 setImmediate(function() { //prevent timeout
     console.log("[*] Starting script");
 
@@ -1259,7 +1259,7 @@ Wrap your code in the function `setImmediate` to prevent timeouts (you may or ma
 
 Save the above script as `uncrackable1.js` and load it:
 
-```
+```shell
 frida -U -l uncrackable1.js sg.vantagepoint.uncrackable1
 ```
 
@@ -1269,7 +1269,7 @@ You can now try to input a "secret string." But where do you get it?
 
 If you look at the class `sg.vantagepoint.uncrackable1.a`, you can see the encrypted string with which your input gets compared:
 
-```
+```java
 package sg.vantagepoint.uncrackable1;
 
 import android.util.Base64;
@@ -1307,7 +1307,7 @@ Notice the `string.equals` comparison at the end of the `a` method and the creat
 Instead of reversing the decryption routines to reconstruct the secret key, you can simply ignore all the decryption logic in the app and hook the `sg.vantagepoint.a.a.a` function to catch its return value.
 Here is the complete script that prevents exiting on root and intercepts the decryption of the secret string:
 
-```
+```java
 setImmediate(function() {
     console.log("[*] Starting script");
 
@@ -1337,7 +1337,7 @@ setImmediate(function() {
 
 After running the script in Frida and seeing the "[*] sg.vantagepoint.a.a.a modified" message in the console, enter a random value for "secret string" and press verify. You should get an output similar to the following:
 
-```
+```shell
 michael@sixtyseven:~/Development/frida$ frida -U -l uncrackable1.js sg.vantagepoint.uncrackable1
      ____
     / _  |   Frida 9.1.16 - A world-class dynamic instrumentation framework
@@ -1371,7 +1371,7 @@ Our target program is a simple license key validation program. Granted, you won'
 
 Angr is written in Python 2, and it's available from PyPI. With pip, it's easy to install on \*nix operating systems and Mac OS:
 
-```
+```shell
 $ pip install angr
 ```
 
@@ -1407,7 +1407,7 @@ The main function is located at address 0x1874 in the disassembly (note that thi
 
 The decoded 16-character input string totals 10 bytes, so you know that the validation function expects a 10-byte binary string. Next, look at the core validation function at 0x1760:
 
-```assembly_x68
+```assembly_x86
 .text:00001760 ; =============== S U B R O U T I N E =======================================
 .text:00001760
 .text:00001760 ; Attributes: bp-based frame
@@ -1563,7 +1563,7 @@ Note the last part of the program, where the final input string is retrieved—i
 
 Running this script should return the following:
 
-```
+```shell
 (angr) $ python solve.py
 WARNING | 2017-01-09 17:17:03,664 | cle.loader | The main binary is a position-independent executable. It is being loaded with a base address of 0x400000.
 JQAE6ACMABNAAIIA

--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -1078,7 +1078,7 @@ The -U option lets Frida search for USB devices or emulators.
 To trace specific (low-level) library calls, you can use the `frida-trace` command line tool:
 
 ```shell
-frida-trace -i "open" -U com.android.chrome
+$ frida-trace -i "open" -U com.android.chrome
 ```
 
 This generates a little JavaScript in `__handlers__/libc.so/open.js`, which Frida injects into the process. The script traces all calls to the `open` function in `libc.so`. You can modify the generated script according to your needs with Frida [JavaScript API](https://www.frida.re/docs/javascript-api/).
@@ -1086,13 +1086,13 @@ This generates a little JavaScript in `__handlers__/libc.so/open.js`, which Frid
 Use `frida CLI` to work with Frida interactively. It hooks into a process and gives you a command line interface to Frida's API.
 
 ```shell
-frida -U com.android.chrome
+$ frida -U com.android.chrome
 ```
 
 With the `-l` option, you can also use the Frida CLI to load scripts , e.g., to load `myscript.js`:
 
 ```shell
-frida -U -l myscript.js com.android.chrome
+$ frida -U -l myscript.js com.android.chrome
 ```
 
 Frida also provides a Java API, which is especially helpful for dealing with Android apps. It lets you work with Java classes and objects directly. Here is a script to overwrite the `onResume` function of an Activity class:
@@ -1260,7 +1260,7 @@ Wrap your code in the function `setImmediate` to prevent timeouts (you may or ma
 Save the above script as `uncrackable1.js` and load it:
 
 ```shell
-frida -U -l uncrackable1.js sg.vantagepoint.uncrackable1
+$ frida -U -l uncrackable1.js sg.vantagepoint.uncrackable1
 ```
 
 After you see the "onClickHandler modified" message, you can safely press "OK". The app will not exit anymore.
@@ -1931,7 +1931,7 @@ bf000000 t new_openat    [kernel_hook]
 Now you have everything you need to overwrite the sys_call_table entry. The syntax for kmem_util is:
 
 ```shell
-./kmem_util <syscall_table_base_address> <offset> <func_addr>
+$ ./kmem_util <syscall_table_base_address> <offset> <func_addr>
 ```
 
 The following command patches the openat system call table so that it points to your new function.

--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -695,7 +695,7 @@ Masking of sensitive data, by showing asterisk or dots instead of clear text sho
 
 To make sure an application is masking sensitive user input, check for the following attribute in the definition of EditText:
 
-```
+```xml
 android:inputType="textPassword"
 ```
 

--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -794,23 +794,23 @@ $ dd if=mybackup.ab bs=24 skip=1|openssl zlib -d > mybackup.tar
 In case you get the error `openssl:Error: 'zlib' is an invalid command.` you can try to use Python instead.
 
 ```shell
-dd if=backup.ab bs=1 skip=24 | python -c "import zlib,sys;sys.stdout.write(zlib.decompress(sys.stdin.read()))" > backup.tar
+$ dd if=backup.ab bs=1 skip=24 | python -c "import zlib,sys;sys.stdout.write(zlib.decompress(sys.stdin.read()))" > backup.tar
 ```
 
 The [_Android Backup Extractor_](https://github.com/nelenkov/android-backup-extractor "Android Backup Extractor") is another alternative backup tool. To make the tool to work, you have to download the Oracle JCE Unlimited Strength Jurisdiction Policy Files for [JRE7](https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html "Oracle JCE Unlimited Strength Jurisdiction Policy Files JRE7") or [JRE8](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html "Oracle JCE Unlimited Strength Jurisdiction Policy Files JRE8") and place them in the JRE lib/security folder. Run the following command to convert the tar file:
 
 ```shell
-java -jar abe.jar unpack backup.ab
+$ java -jar abe.jar unpack backup.ab
 ```
 if it shows some Cipher information and usage, which means it hasn't unpacked successfully. In this case you can give a try with more arguments:
 
 ```shell
-abe [-debug] [-useenv=yourenv] unpack <backup.ab> <backup.tar> [password]
+$ abe [-debug] [-useenv=yourenv] unpack <backup.ab> <backup.tar> [password]
 ```
 [password]: is the password when your android device asked you earlier. For example here is: 123
 
 ```shell
-java -jar abe.jar unpack backup.ab backup.tar 123
+$ java -jar abe.jar unpack backup.ab backup.tar 123
 ```
 Extract the tar file to your working directory.
 
@@ -1048,7 +1048,7 @@ For more advanced analysis of the memory dump, use the Eclipse Memory Analyzer (
 To analyze the dump in MAT, use the _hprof-conv_ platform tool, which comes with the Android SDK.
 
 ```shell
-./hprof-conv memory.hprof memory-mat.hprof
+$ ./hprof-conv memory.hprof memory-mat.hprof
 ```
 
 MAT (Memory Analyzer Tool) provides several tools for analyzing the memory dump. For example, the _Histogram_ provides an estimate of the number of objects that have been captured from a given type, and the _Thread Overview_ shows processes' threads and stack frames. The _Dominator Tree_ provides information about keep-alive dependencies between objects. You can use regular expressions to filter the results these tools provide.

--- a/Document/0x05h-Testing-Platform-Interaction.md
+++ b/Document/0x05h-Testing-Platform-Interaction.md
@@ -258,7 +258,7 @@ Package: com.android.mms.service
 
 When Android applications expose IPC components to other applications, they can define permissions to control which applications can access the components. For communication with a component protected by a `normal` or `dangerous` permission, Drozer can be rebuilt so that it includes the required permission:
 
-```
+```shell
 $ drozer agent build  --permission android.permission.REQUIRED_PERMISSION
 ```
 
@@ -429,7 +429,7 @@ Check the source code for the class `android.app.Service`:
 
 By reversing the target application, we can see that the service `AuthService` provides functionality for changing the password and PIN-protecting the target app.
 
-```
+```java
    public void handleMessage(Message msg) {
             AuthService.this.responseHandler = msg.replyTo;
             Bundle returnBundle = msg.obj;
@@ -482,7 +482,7 @@ To understand more about what the receiver is intended to do, we have to go deep
 
 The following extract of the target application's source code shows that the broadcast receiver triggers transmission of an SMS message containing the user's decrypted password.
 
-```
+```java
 public class MyBroadCastReceiver extends BroadcastReceiver {
   String usernameBase64ByteString;
   public static final String MYPREFS = "mySharedPreferences";
@@ -890,7 +890,7 @@ Steps:
 
 The following example shows an Activity that extends this activity:
 
-```
+```java
 public class MyPreferences extends PreferenceActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/Document/0x05i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x05i-Testing-Code-Quality-and-Build-Settings.md
@@ -37,7 +37,7 @@ The contents of the signing certificate can be examined with `jarsigner`. Note t
 
 The output for an APK signed with a debug certificate is shown below:
 
-```
+```shell
 $ jarsigner -verify -verbose -certs example.apk
 
 sm     11116 Fri Nov 11 12:07:48 ICT 2016 AndroidManifest.xml
@@ -78,7 +78,7 @@ Check `AndroidManifest.xml` to determine whether the `android:debuggable` attrib
 ```xml
     ...
     <application android:allowBackup="true" android:debuggable="true" android:icon="@drawable/ic_launcher" android:label="@string/app_name" android:theme="@style/AppTheme">
-    …
+    ...
 ```
 
 For a release build, this attribute should always be set to "false" (the default value).
@@ -113,7 +113,7 @@ Package: com.vulnerable.app
 
 If an application is debuggable, executing application commands is trivial. In the `adb` shell, execute `run-as` by appending the package name and application command to the binary name:
 
-```
+```shell
 $ run-as com.vulnerable.app id
 uid=10084(u0_a84) gid=10084(u0_a84) groups=10083(u0_a83),1004(input),1007(log),1011(adb),1015(sdcard_rw),1028(sdcard_r),3001(net_bt_admin),3002(net_bt),3003(inet),3006(net_bw_stats) context=u:r:untrusted_app:s0:c512,c768
 ```
@@ -126,7 +126,7 @@ The following procedure can be used to start a debug session with `jdb`:
 
 1. Using `adb` and `jdwp`, identify the PID of the active application that you want to debug:
 
-```
+```shell
 $ adb jdwp
 2355
 16346  <== last launched, corresponds to our application
@@ -134,14 +134,14 @@ $ adb jdwp
 
 2. Create a communication channel by using `adb` between the application process (with the PID) and the analysis workstation by using a specific local port:
 
-```
+```shell
 # adb forward tcp:[LOCAL_PORT] jdwp:[APPLICATION_PID]
 $ adb forward tcp:55555 jdwp:16346
 ```
 
 3. Using `jdb`, attach the debugger to the local communication channel port and start a debug session:
 
-```
+```shell
 $ jdb -connect com.sun.jdi.SocketAttach:hostname=localhost,port=55555
 Set uncaught java.lang.Throwable
 Set deferred uncaught java.lang.Throwable
@@ -192,11 +192,11 @@ Dynamic symbols can be stripped via the `visibility` compiler flag. Adding this 
 Make sure that the following has been added to build.gradle:
 
 ```
-        externalNativeBuild {
-            cmake {
-                cppFlags "-fvisibility=hidden"
-            }
-        }
+externalNativeBuild {
+    cmake {
+        cppFlags "-fvisibility=hidden"
+    }
+}
 ```
 
 #### Dynamic Analysis
@@ -431,11 +431,11 @@ public class MemoryCleanerOnCrash implements Thread.UncaughtExceptionHandler {
 Now the handler's initializer must be called in your custom `Application` class (e.g., the class that extends `Application`):
 
 ```java
-	 @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        MemoryCleanerOnCrash.init();
-    }
+@Override
+protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MemoryCleanerOnCrash.init();
+}
 ```
 
 #### Dynamic Analysis

--- a/Document/0x05i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x05i-Testing-Code-Quality-and-Build-Settings.md
@@ -355,14 +355,14 @@ The tester should manually test the input fields with strings like `OR 1=1--` if
 
 On a rooted device, the command content can be used to query the data from a Content Provider. The following command queries the vulnerable function described above.
 
-```
-content query --uri content://sg.vp.owasp_mobile.provider.College/students
+```shell
+# content query --uri content://sg.vp.owasp_mobile.provider.College/students
 ```
 
 SQL injection can be exploited with the following command. Instead of getting the record for Bob only, the user can retrieve all data.
 
-```
-content query --uri content://sg.vp.owasp_mobile.provider.College/students --where "name='Bob') OR 1=1--''"
+```shell
+# content query --uri content://sg.vp.owasp_mobile.provider.College/students --where "name='Bob') OR 1=1--''"
 ```
 
 Drozer can also be used for dynamic testing.
@@ -593,8 +593,8 @@ apply plugin: 'org.owasp.dependencycheck'
 Once gradle has invoked the plugin, you can create a report by running:
 
 ```sh
-gradle assemble
-gradle dependencyCheckAnalyze --info
+$ gradle assemble
+$ gradle dependencyCheckAnalyze --info
 ```
 
 The report will be in `build/reports` unless otherwise configured. Use the report in order to analyse the vulnerabilities found. See remediation on what to do given the vulnerabilities found with the libraries.
@@ -626,8 +626,8 @@ plugins {
 Now, after the plugin is picked up, use the following commands:
 
 ```sh
-gradle assemble
-gradle downloadLicenses
+$ gradle assemble
+$ gradle downloadLicenses
 ```
 
 Now a license-report will be generated, which can be used to consult the licenses used by the third party libraries. Please check the license agreemts to see whether a copyright notice needs to be included into the app and whether the licensetype requires to open-source the code of the application.

--- a/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -27,7 +27,7 @@ To use the API, an app may call the `SafetyNetApi.attest` method (which returns 
 
 The following is a sample attestation result:
 
-```
+```json
 {
   "nonce": "R2Rra24fVm5xa2Mg",
   "timestampMs": 9860437986543,
@@ -151,7 +151,7 @@ Unusual permissions on system directories may indicate a customized or rooted de
 
 Checking for signs of test builds and custom ROMs is also helpful. One way to do this is to check the BUILD tag for test-keys, which normally [indicate a custom Android image](https://resources.infosecinstitute.com/android-hacking-security-part-8-root-detection-evasion// "InfoSec Institute - Android Root Detection and Evasion"). [Check the BUILD tag as follows](https://www.joeyconway.com/blog/2014/03/29/android-detect-root-access-from-inside-an-app/ "Android - Detect Root Access from inside an app"):
 
-```
+```java
 private boolean isTestKeyBuild()
 {
 String str = Build.TAGS;
@@ -223,7 +223,7 @@ We have already encountered the `android:debuggable` attribute. This flag in the
 
 The `Android Debug` system class offers a static method to determine whether a debugger is connected. The method returns a boolean value.
 
-```
+```java
     public static boolean detectDebugger() {
         return Debug.isDebuggerConnected();
     }
@@ -231,7 +231,7 @@ The `Android Debug` system class offers a static method to determine whether a d
 
 The same API can be called via native code by accessing the DvmGlobals global structure.
 
-```
+```c
 JNIEXPORT jboolean JNICALL Java_com_test_debugging_DebuggerConnectedJNI(JNIenv * env, jobject obj) {
     if (gDvm.debuggerConnected || gDvm.debuggerActive)
         return JNI_TRUE;
@@ -243,7 +243,7 @@ JNIEXPORT jboolean JNICALL Java_com_test_debugging_DebuggerConnectedJNI(JNIenv *
 
 `Debug.threadCpuTimeNanos` indicates the amount of time that the current thread has been executing code. Because debugging slows down process execution, [you can use the difference in execution time to guess whether a debugger is attached](https://slides.night-labs.de/AndroidREnDefenses201305.pdf "Bluebox Security - Android Reverse Engineering & Defenses").
 
-```
+```java
 static boolean detect_threadCpuTimeNanos(){
   long start = Debug.threadCpuTimeNanos();
 
@@ -373,7 +373,7 @@ When the `ptrace` system call is used to attach to a process, the "TracerPid" fi
 
 The following implementation is from [Tim Strazzere's Anti-Emulator project](https://github.com/strazzere/anti-emulator/):
 
-```
+```java
     public static boolean hasTracerPid() throws IOException {
         BufferedReader reader = null;
         try {
@@ -406,7 +406,7 @@ On Linux, the [`ptrace` system call](http://man7.org/linux/man-pages/man2/ptrace
 
 You can prevent debugging of a process by forking a child process and attaching it to the parent as a debugger via code similar to the following simple example code:
 
-```
+```c
 void fork_and_attach()
 {
   int pid = fork();
@@ -934,7 +934,7 @@ void scan() {
 
 Note the use of `my_openat`, etc., instead of the normal libc library functions. These are custom implementations that do the same things as their Bionic libc counterparts: they set up the arguments for the respective system call and execute the `swi` instruction (see the following code). Using these functions eliminates the reliance on public APIs, thus making them less susceptible to the typical libc hooks. The complete implementation is in `syscall.S`. The following is an assembler implementation of `my_openat`.
 
-```
+```arm
 #include "bionic_asm.h"
 
 .text

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -158,15 +158,15 @@ Life is easy with a jailbroken device: not only do you gain easy access to the a
 
 The following commands install the dependencies required to run Needle on Linux.
 
-```
+```shell
 # Unix packages
-sudo apt-get install python2.7 python2.7-dev sshpass sqlite3 lib32ncurses5-dev
+$ sudo apt-get install python2.7 python2.7-dev sshpass sqlite3 lib32ncurses5-dev
 
 # Python packages
-sudo pip install readline paramiko sshtunnel frida mitmproxy biplist
+$ sudo pip install readline paramiko sshtunnel frida mitmproxy biplist
 
 # Download source
-git clone https://github.com/mwrlabs/needle.git
+$ git clone https://github.com/mwrlabs/needle.git
 
 ```
 
@@ -174,28 +174,28 @@ git clone https://github.com/mwrlabs/needle.git
 
 The following commands install the dependencies required to run Needle on macOS.
 
-```
+```shell 
 # Core dependencies
-brew install python
-brew install libxml2
-xcode-select --install
+$ brew install python
+$ brew install libxml2
+$ xcode-select --install
 
 # Python packages
-sudo -H pip install --upgrade --user readline
-sudo -H pip install --upgrade --user paramiko
-sudo -H pip install --upgrade --user sshtunnel
-sudo -H pip install --upgrade --user frida
-sudo -H pip install --upgrade --user biplist
+$ sudo -H pip install --upgrade --user readline
+$ sudo -H pip install --upgrade --user paramiko
+$ sudo -H pip install --upgrade --user sshtunnel
+$ sudo -H pip install --upgrade --user frida
+$ sudo -H pip install --upgrade --user biplist
 # sshpass
-brew install https://raw.githubusercontent.com/kadwanev/bigboybrew/master/Library/Formula/sshpass.rb
+$ brew install https://raw.githubusercontent.com/kadwanev/bigboybrew/master/Library/Formula/sshpass.rb
 
 # mitmproxy
-wget https://github.com/mitmproxy/mitmproxy/releases/download/v0.17.1/mitmproxy-0.17.1-osx.tar.gz
-tar -xvzf mitmproxy-0.17.1-osx.tar.gz
-sudo cp mitmproxy-0.17.1-osx/mitm* /usr/local/bin/
+$ wget https://github.com/mitmproxy/mitmproxy/releases/download/v0.17.1/mitmproxy-0.17.1-osx.tar.gz
+$ tar -xvzf mitmproxy-0.17.1-osx.tar.gz
+$ sudo cp mitmproxy-0.17.1-osx/mitm* /usr/local/bin/
 
 # Download source
-git clone https://github.com/mwrlabs/needle.git
+$ git clone https://github.com/mwrlabs/needle.git
 ```
 
 ##### Install the Needle Agent
@@ -229,7 +229,7 @@ The only prerequisite is a Jailbroken device, with the following packages instal
 
 To launch Needle, just open a console and type:
 
-```
+```shell 
 $ python needle.py
       __  _ _______ _______ ______         ______
       | \ | |______ |______ | \     |      |______

--- a/Document/0x06c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x06c-Reverse-Engineering-and-Tampering.md
@@ -50,8 +50,8 @@ itms-services://?action=download-manifest&url=https://s3-ap-southeast-1.amazonaw
 
 You can use the [ITMS services asset downloader](https://www.npmjs.com/package/itms-services "ITMS services asset downloader") tool to download the IPS from an OTA distribution URL. Install it via npm:
 
-```
-npm install -g itms-services
+```shell 
+$ npm install -g itms-services
 ```
 
 Save the IPA file locally with the following command:
@@ -195,8 +195,8 @@ You'll find the debugserver executable in the `/usr/bin/` directory on the mount
 
 Apply the entitlement with codesign:
 
-```
-codesign -s - --entitlements entitlements.plist -f debugserver
+```shell
+$ codesign -s - --entitlements entitlements.plist -f debugserver
 ```
 
 Copy the modified binary to any directory on the test device. The following examples use usbmuxd to forward a local port through USB.

--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -95,7 +95,7 @@ On iOS, when an application is uninstalled, the Keychain data used by the applic
 When assessing an iOS application, you should look for Keychain data persistence. This is normally done by using the application to generate sample data that may be stored in the Keychain, uninstalling the application, then reinstalling the application to see whether the data was retained between application installations. You can also verify persistence by using the iOS security assessment framework Needle to read the Keychain. The following Needle commands demonstrate this procedure:
 
 ```
-python needle.py
+$ python needle.py
 [needle] > use storage/data/keychain_dump
 [needle] > run
   {
@@ -414,8 +414,8 @@ A generalized approach to this issue is to use a define to enable `NSLog` statem
 Navigate to a screen that displays input fields that take sensitive user information. Two methods apply to checking log files for sensitive data:
 
 1. Connect to the iOS device and execute the following command:
-```
-tail -f /var/log/syslog
+```shell
+$ tail -f /var/log/syslog
 ```
 
 2. Connect your iOS device via USB and launch Xcode. Navigate to Window > Devices and Simulators, select your device and then the Open Console option (as of Xcode 9).

--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -610,7 +610,7 @@ Both file system properties are preferable to the deprecated approach of directl
 
 The following is [sample Objective-C code for excluding a file from a backup](https://developer.apple.com/library/content/qa/qa1719/index.html "How do I prevent files from being backed up to iCloud and iTunes?") on iOS 5.1 and later:
 
-```#ObjC
+```ObjC
 - (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *) filePathString
 {
     NSURL* URL= [NSURL fileURLWithPath: filePathString];
@@ -628,7 +628,7 @@ The following is [sample Objective-C code for excluding a file from a backup](ht
 
 The following is [sample Swift code for excluding a file from a backup](https://developer.apple.com/library/content/qa/qa1719/index.html "How do I prevent files from being backed up to iCloud and iTunes?") on iOS 5.1 and later:
 
-```
+```swift
  func addSkipBackupAttributeToItemAtURL(filePath:String) -> Bool
     {
         let URL:NSURL = NSURL.fileURLWithPath(filePath)
@@ -671,7 +671,7 @@ While analyzing the source code, look for the fields or screens that take or dis
 
 The following is a sample remediation method that will set a default screenshot:
 
-```
+```objc
 @property (UIImageView *)backgroundImage;
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
@@ -791,7 +791,7 @@ Memory dumped to file: /Users/foo/memory_iOS/memory
 
 After the memory has been dumped, executing the command `strings` with the dump as argument will extract the strings.
 
-```
+```shell
 $ strings memory > strings.txt
 ```
 

--- a/Document/0x06e-Testing-Cryptography.md
+++ b/Document/0x06e-Testing-Cryptography.md
@@ -10,7 +10,7 @@ iOS code usually refers to constants defined in `CommonCryptor.h` (for example, 
 
 If the app uses standard cryptographic implementations provided by Apple, the easiest way to determine the status of the related algorithm is to check for calls to functions from `CommonCryptor`, such as `CCCrypt` and `CCCryptorCreate`. The [source code](https://opensource.apple.com/source/CommonCrypto/CommonCrypto-36064/CommonCrypto/CommonCryptor.h "CommonCryptor.h") contains the signatures of all functions of CommonCryptor.h. For instance, `CCCryptorCreate` has following signature:
 
-```
+```c
 CCCryptorStatus CCCryptorCreate(
 	CCOperation op,             /* kCCEncrypt, etc. */
 	CCAlgorithm alg,            /* kCCAlgorithmDES, etc. */
@@ -32,19 +32,19 @@ Apple provides a [Randomization Services](https://developer.apple.com/reference/
 The Randomization Services API uses the `SecRandomCopyBytes` function to generate numbers. This is a wrapper function for the `/dev/random` device file, which provides cryptographically secure pseudorandom values from 0 to 255. Make sure that all random numbers are generated with this API-there is no reason for developers to use a different one.
 
 In Swift, the [`SecRandomCopyBytes` API](https://developer.apple.com/reference/security/1399291-secrandomcopybytes "SecRandomCopyBytes (Swift)") is defined as follows:
-```
+```swift
 func SecRandomCopyBytes(_ rnd: SecRandomRef?,
                       _ count: Int,
                       _ bytes: UnsafeMutablePointer<UInt8>) -> Int32
 ```
 
 The [Objective-C version](https://developer.apple.com/reference/security/1399291-secrandomcopybytes?language=objc "SecRandomCopyBytes (Objective-C)") is
-```
+```objc
 int SecRandomCopyBytes(SecRandomRef rnd, size_t count, uint8_t *bytes);
 ```
 
 The following is an example of the APIs usage:
-```
+```objc
 int result = SecRandomCopyBytes(kSecRandomDefault, 16, randomBytes);
 ```
 

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -96,7 +96,7 @@ If the source code is available, open then `Info.plist` file in the application 
 
 The following listing is an example of an exception configured to disable ATS restrictions globally.
 
-```
+```xml
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -108,7 +108,7 @@ If the source code is not available, then the `Info.plist` file should be either
 
 Since IPA files are ZIP archives, they can be extracted using any zip utility.
 
-```
+```shell
 $ unzip app-name.ipa
 ```
 
@@ -118,7 +118,7 @@ $ unzip app-name.ipa
 
 The following command shows how to convert the Info.plist file into XML format.
 
-```
+```shell
 $ plutil -convert xml1 Info.plist
 ```
 
@@ -129,7 +129,7 @@ In general it can be summarised:
 - ATS should be configured according to best practices by Apple and only be deactivated under certain circumstances.
 - If the application connects to a defined number of domains that the application owner controls, then configure the servers to support the ATS requirements and opt-in for the ATS requirements within the app. In the following example, `example.com` is owned by the application owner and ATS is enabled for that domain.
 
-```
+```xml
 <key>NSAppTransportSecurity</key>
 <dict>
     <key>NSAllowsArbitraryLoads</key>
@@ -176,7 +176,7 @@ The code presented below shows how it is possible to check if the certificate pr
 
 The delegate must implement `connection:canAuthenticateAgainstProtectionSpace:` and `connection: forAuthenticationChallenge`. Within `connection: forAuthenticationChallenge`, the delegate must call `SecTrustEvaluate` to perform customary X509 checks. The snippet below implements a check of the certificate.  
 
-```
+```objc
 (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
   SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;

--- a/Document/0x06h-Testing-Platform-Interaction.md
+++ b/Document/0x06h-Testing-Platform-Interaction.md
@@ -43,7 +43,6 @@ For example, when you have a Info.plist file, for a Solitair game which has, at 
 <string>Share your health data with us!</string>
 <key>NSCameraUsageDescription</key>
 <string>We want to access your camera</string>
-
 ```
 Should be suspicious as a normal solitair game probably does not have any need for accessing the camera nor a user's health-records.
 Note that from iOS 10 onward you need to provide explanation in terms of these \*Description fields. See table 1-2 at the [Apple app programming guide](https://developer.apple.com/library/archive/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/ExpectedAppBehaviors/ExpectedAppBehaviors.html#//apple_ref/doc/uid/TP40007072-CH3-SW7 "Apple app programming guide") for a more complete overview of different keys to look for.
@@ -61,7 +60,6 @@ The entitlements file shows which capabilities are used. Some of these capabilit
   <array/>
 </dict>
 </plist>
-
 ```
 
 Note that this requirement is not always necessary to "bleed" information from one application to another. You can have a back-end as a medium between two applications to share information as well.

--- a/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -46,7 +46,7 @@ These symbols can be saved in "Stabs" format or the DWARF format. In the Stabs f
 
 Use gobjdump to inspect the main binary and any included dylibs for Stabs and DWARF symbols.
 
-```
+```shell
 $ gobjdump --stabs --dwarf TargetApp
 In archive MyTargetApp:
 

--- a/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -382,14 +382,14 @@ In case CocoaPods is used for managing third party dependencies, the following s
 
 1. At the root of the project, where the Podfile is located, execute the following commands:
 ``` sh
-sudo gem install CocoaPods
-pod install
+$ sudo gem install CocoaPods
+$ pod install
 ```
 
 2. Now that the dependency tree has bene built, you can create an overview of the dependencies and their versions by running the following commands:
 ```sh
-sudo gem install CocoaPods-dependencies
-pod dependencies
+$ sudo gem install CocoaPods-dependencies
+$ pod dependencies
 ```
 
 3. The result of the steps above can now be used as input for searching different vulnerability feeds for known vulnerabilities.
@@ -402,8 +402,8 @@ pod dependencies
 In case Carthage is used for third party dependencies, then the following steps can be taken to analyse the third party libraries for vulnerabilities:
 1. At the root of the project, where the Cartfile is located, type
 ```sh
-brew install carthage
-carthage update --platform iOS
+$ brew install carthage
+$ carthage update --platform iOS
 ```
 
 2. Check the Cartfile.resolved for actual versions used and inspect the given libraries for known vulnerabilities.
@@ -422,18 +422,17 @@ In order to ensure that the copyright laws are not infringed, one can best check
 
 When the application sources are available and CocoaPods is used, then execute the following steps to get the different licenses:
 1. At the root of the project, where the Podfile is located, type
-``` sh
-sudo gem install CocoaPods
-pod install
-
+```sh
+$ sudo gem install CocoaPods
+$ pod install
 ```
 2. At the Pods folder you will find the libraries installed. Each in their own folder. Now you can check the licenses for each of the libraries by inspecting the license files in each of the folders.
 
 When the application sources are available and Carthage is used, then execute the following steps to get the different licenses:
 1. At the root of the project, where the Cartfile is located, type
 ```sh
-brew install carthage
-carthage update --platform iOS
+$ brew install carthage
+$ carthage update --platform iOS
 ```
 
 2. The sources of each of the dependencies have been downloaded to `Carthage/Checkouts` folder in the project. Here you can find the license for each of the libraries in their respective folder.
@@ -453,13 +452,13 @@ When no source-code is available for library analysis, you can find some of the 
 After you obtain the library and Clutched it (e.g. removed the DRM), you can run oTool with at the root of the <Application.app> directory:
 
 ```shell
-otool -L <Executable>
+$ otool -L <Executable>
 ```
 
 However, these do not include all the libraries being used. Next, with Class-dump (for Objective-C) you can generate a subset of the headerfiles used and derive which libraries are involved. But not detect the version of the library.
 
 ```shell
-./class-dump <Executable> -r
+$ ./class-dump <Executable> -r
 ```
 
 ### References

--- a/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -65,7 +65,7 @@ if(error==nil){
 
 You can check protocol handlers by attempting to open a Cydia URL. The Cydia app store, which practically every jailbreaking tool installs by default, installs the cydia:// protocol handler.
 
-```
+```objc
 if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"cydia://package/com.example.package"]]){
 ```
 
@@ -91,7 +91,7 @@ As you can see, there's a class method (`+[SFAntiPiracy isTheDeviceJailbroken]`)
 
 Let's inject Cycript into our process (look for your PID with `top`):
 
-```
+```sh
 iOS8-jailbreak:~ root# cycript -p 12345
 cy# [SFAntiPiracy isTheDeviceJailbroken]
 true


### PR DESCRIPTION
- Added the proper language syntax to code chunks to get it properly highlighted.
- Fixed some inconsistencies in code indentation.
- Added some $ at the beginning of console commands.

There is more work pending around this. I think I will open an issue to talk about it and see if there is already a standard in this project, e.g. should all console commands start with $ to differentiate the input command from output? or max line length in code chunks...
