### PR TITLE
Change syslog access by ondeviceconsole

### DIFF
--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -415,9 +415,9 @@ A generalized approach to this issue is to use a define to enable `NSLog` statem
 
 Navigate to a screen that displays input fields that take sensitive user information. Two methods apply to checking log files for sensitive data:
 
-1. Connect to the iOS device and execute the following command:
+1. Connect to the iOS device and execute the following command (available through Cydia):
 ```shell
-$ tail -f /var/log/syslog
+$ ondeviceconsole
 ```
 
 2. Connect your iOS device via USB and launch Xcode. Navigate to Window > Devices and Simulators, select your device and then the Open Console option (as of Xcode 9).


### PR DESCRIPTION
The standard Unix log file (tail -f /var/log/syslog) does not exist in several iOS versions (if any). A tool to access ASL is ondeviceconsole.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #<insert number here>.
