### PR TITLE
Installing needle dependencies, apt-get

### DIFF
--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -278,7 +278,7 @@ The tool has the following global options (list them via the `show options` comm
 - **SAVE_HISTORY**: If set to "true," the command history will persist across sessions.
 - **VERBOSE, DEBUG**: If set to "true," this will enable verbose and debug logging, respectively.
 
-**Trouble shooting**
+**Troubleshooting**
 
 Please pay attention, in order to use the modules in Needle. You might have to install its dependencies by using this command in Neelde.
 

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -287,9 +287,7 @@ use device/dependency_installer
 
 run
 ```
-Other module may promt you the ```apt-get``` command has not been installed. To get ```apt-get```, go to your Cydia and look for  ```CyDelete``` and install it. 
-
-This will install the needed dependencies, command lines for later use.
+Other modules may promt you the ```apt-get``` command has not been installed. To get ```apt-get```, go to your Cydia and look for  ```CyDelete``` and install it. 
 
 #### SSH Connection via USB
 

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -278,6 +278,18 @@ The tool has the following global options (list them via the `show options` comm
 - **SAVE_HISTORY**: If set to "true," the command history will persist across sessions.
 - **VERBOSE, DEBUG**: If set to "true," this will enable verbose and debug logging, respectively.
 
+**Trouble shooting**
+
+Please pay attention, in order to use the modules in Needle. You might have to install its dependencies by using this command in Neelde.
+
+```
+use device/dependency_installer
+
+run
+```
+Other module may promt you the ```apt-get``` command has not been installed. To get ```apt-get```, go to your Cydia and look for  ```CyDelete``` and install it. 
+
+This will install the needed dependencies, command lines for later use.
 
 #### SSH Connection via USB
 

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -280,7 +280,7 @@ The tool has the following global options (list them via the `show options` comm
 
 **Troubleshooting**
 
-Please pay attention, in order to use the modules in Needle. You might have to install its dependencies by using this command in Neelde.
+In order to use the modules in Needle, you may have to install its dependencies. Use this command in Needle:
 
 ```
 use device/dependency_installer

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -282,12 +282,12 @@ The tool has the following global options (list them via the `show options` comm
 
 In order to use the modules in Needle, you may have to install its dependencies. Use this command in Needle:
 
-```
+```shell
 use device/dependency_installer
 
 run
 ```
-Other modules may promt you the ```apt-get``` command has not been installed. To get ```apt-get```, go to your Cydia and look for  ```CyDelete``` and install it. 
+Other modules may promt you the `apt-get` command has not been installed. To get `apt-get`, go to your Cydia and look for  `CyDelete` and install it. 
 
 #### SSH Connection via USB
 


### PR DESCRIPTION
I've been spending 2 hours to fix the error when I tried to use the modules in Needle. It shown me an error regarding the lack of command line as such lipo or apt-get command isn't available.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #<insert number here>.
