### PR TITLE
Added method to use Fridump in no-jailbroken device

### DIFF
--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -819,6 +819,8 @@ libdyld.dylib                     0x185c81000  20480 (20.0 KiB)     /usr/lib/sys
 
 ##### Fridump (No Jailbreak needed)
 
+To use Fridump you need to have either a jailbroken/rooted device with Frida-server installed. The only other way this can be achieved is by building the original application with the Frida library attached (instructions on Frida’s site) [here](https://www.frida.re/docs/ios/)
+
 The original version of Fridump is no longer maintained, and the tool works only with Python 2. The latest Python version (3.x) should be used for Frida, so Fridump doesn't work out of the box.
 
 If you're getting the following error message despite your iOS device being connected via USB, checkout [Fridump with the fix for Python 3](https://github.com/sushi2k/fridump "Fridump for Python3").

--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -819,7 +819,7 @@ libdyld.dylib                     0x185c81000  20480 (20.0 KiB)     /usr/lib/sys
 
 ##### Fridump (No Jailbreak needed)
 
-To use Fridump you need to have either a jailbroken/rooted device with Frida-server installed. The only other way this can be achieved is by building the original application with the Frida library attached (instructions on Frida’s site) [here](https://www.frida.re/docs/ios/)
+To use Fridump you need to have either a jailbroken/rooted device with Frida-server installed, or build the original application with the Frida library attached instructions on [Frida’s site](https://www.frida.re/docs/ios/)
 
 The original version of Fridump is no longer maintained, and the tool works only with Python 2. The latest Python version (3.x) should be used for Frida, so Fridump doesn't work out of the box.
 


### PR DESCRIPTION
To use Fridump you need to have either a jailbroken/rooted device with Frida-server installed. But there is possible guided by Frida website

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #<insert number here>.
