### PR TITLE
Build.TAGS with "test-keys" value means that test keys has been used while signing during the build process, and has nothing to do with the app being running on an emulator. I already tested it on an application that i made which shows the Build.TAGS value. i run it on android emulator Nexus 5X with API Level 25 and it shows "release-keys".  

### DIFF
--- a/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -1015,7 +1015,6 @@ Build.MODEL         sdk             emulator
 Build.PRODUCT       sdk             emulator
 Build.RADIO         unknown         possibly emulator
 Build.SERIAL        null            emulator
-Build.TAGS          test-keys       emulator
 Build.USER          android-build   emulator
 ```
 


### PR DESCRIPTION
…t the key used to sign during the build process is a test key

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #<insert number here>.
