### PR TITLE
Fix to small typo in code sample in 0x05e

### DIFF
--- a/Document/0x05e-Testing-Cryptography.md
+++ b/Document/0x05e-Testing-Cryptography.md
@@ -245,7 +245,7 @@ public static SecretKey generateStrongAESKey(char[] password, int keyLength)
 
     //Generate the salt
     byte[] salt = new byte[saltLength];
-    randomb.nextBytes(salt);
+    random.nextBytes(salt);
 
     KeySpec keySpec = new PBEKeySpec(password.toCharArray(), salt, iterationCount, keyLength);
     SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");


### PR DESCRIPTION
Proposing a fix to a very small typo in a code sample in the 0x5e Testing Cryptography guide