### PR TITLE
Alternative command added for adb backup

### DIFF
--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -796,6 +796,11 @@ After executing all available app functions, attempt to back up via `adb`. If th
 ```shell
 $ adb backup -apk -nosystem <package-name>
 ```
+If the afore adb backup command gives the message  "Now unlock your device and confirm the backup operation", but the mobile phone does not ask for the password to encrypt the package. The mobile phone should promt the Full Backup windows and asks for a password, this password later used for tar extraction. If the phone does not promt, try afore command with qoutes:
+
+```shell
+$ adb backup "-apk -nosystem <package-name>"
+```
 
 Approve the backup from your device by selecting the _Back up my data_ option. After the backup process is finished, the file _.ab_ will be in your working directory.
 Run the following command to convert the .ab file to tar.

--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -801,7 +801,7 @@ ADB should respond now with "Now unlock your device and confirm the backup opera
 ```shell
 $ adb backup "-apk -nosystem <package-name>"
 ```
-The problem happens when your device has an adb version prior to 1.0.31. If that's the case you must use an adb version of 1.0.31 also on hour host machine. Versions of adb after 1.0.32 [broke the backwards compatibility.](https://issuetracker.google.com/issues/37096097)
+The problem happens when your device has an adb version prior to 1.0.31. If that's the case you must use an adb version of 1.0.31 also on your host machine. Versions of adb after 1.0.32 [broke the backwards compatibility.](https://issuetracker.google.com/issues/37096097 "adb backup is broken since ADB version 1.0.32")
 
 Approve the backup from your device by selecting the _Back up my data_ option. After the backup process is finished, the file _.ab_ will be in your working directory.
 Run the following command to convert the .ab file to tar.

--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -801,6 +801,7 @@ ADB should respond now with "Now unlock your device and confirm the backup opera
 ```shell
 $ adb backup "-apk -nosystem <package-name>"
 ```
+The problem happens when your device has an adb version prior to 1.0.31. If that's the case you must use an adb version of 1.0.31 also on hour host machine. Versions of adb after 1.0.32 [broke the backwards compatibility.](https://issuetracker.google.com/issues/37096097)
 
 Approve the backup from your device by selecting the _Back up my data_ option. After the backup process is finished, the file _.ab_ will be in your working directory.
 Run the following command to convert the .ab file to tar.

--- a/Document/0x05d-Testing-Data-Storage.md
+++ b/Document/0x05d-Testing-Data-Storage.md
@@ -796,7 +796,7 @@ After executing all available app functions, attempt to back up via `adb`. If th
 ```shell
 $ adb backup -apk -nosystem <package-name>
 ```
-If the afore adb backup command gives the message  "Now unlock your device and confirm the backup operation", but the mobile phone does not ask for the password to encrypt the package. The mobile phone should promt the Full Backup windows and asks for a password, this password later used for tar extraction. If the phone does not promt, try afore command with qoutes:
+ADB should respond now with "Now unlock your device and confirm the backup operation" and you should be asked on the Android phone for a password. This is an optional step and you don't need to provide one. If the phone does not prompt this message, try the following command including the quotes:
 
 ```shell
 $ adb backup "-apk -nosystem <package-name>"


### PR DESCRIPTION
Instead of finding an older adb tool version, putting the argument within quotes will help  eg: $ adb backup "-apk -nosystem <package-name>"

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #<insert number here>.
