### PR TITLE
Fixing tools and refs

### DIFF
--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -1749,8 +1749,18 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 
 - Signing Manually (Android developer documentation) - <https://developer.android.com/studio/publish/app-signing#signing-manually>
 - Custom Trust - <https://developer.android.com/training/articles/security-config#CustomTrust>
-- Google Android Codelabs - <https://codelabs.developers.google.com/codelabs/android-network-security-config/#3>
+- Basic Network Security Configuration - <https://codelabs.developers.google.com/codelabs/android-network-security-config/#3>
 - Security Analyst’s Guide to Network Security Configuration in Android P - <https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/>
 - Android developer documentation - <https://developer.android.com/studio/publish/app-signing#signing-manually>
 - Android 8.0 Behavior Changes - <https://developer.android.com/about/versions/oreo/android-8.0-changes>
 - Android 9.0 Behavior Changes - <https://developer.android.com/about/versions/pie/android-9.0-changes-all#device-security-changes>
+- Codenames, Tags and Build Numbers - <https://source.android.com/setup/start/build-numbers>
+- Create and Manage Virtual Devices - <https://developer.android.com/studio/run/managing-avds.html>
+- Guide to rooting mobile devices - <https://www.xda-developers.com/root/>
+- API Levels - <https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels>
+- AssetManager - <https://developer.android.com/reference/android/content/res/AssetManager>
+- SharedPreferences APIs - <https://developer.android.com/training/basics/data-storage/shared-preferences.html>
+- Debugging with Logcat - <https://developer.android.com/tools/debugging/debugging-log.html>
+- Android's .apk format - <https://en.wikipedia.org/wiki/Android_application_package>
+- Android remote sniffing using Tcpdump, nc and Wireshark - <https://blog.dornea.nu/2015/02/20/android-remote-sniffing-using-tcpdump-nc-and-wireshark/>
+- Wireless Client Isolation - <https://documentation.meraki.com/MR/Firewall_and_Traffic_Shaping/Wireless_Client_Isolation>

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -66,8 +66,8 @@ Although there exist several free Android emulators, we recommend using AVD as i
 
 Several tools and VMs that can be used to test an app within an emulator environment are available:
 
-- MobSF
-- Nathan (not updated since 2016)
+- [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF "MobSF")
+- [Nathan](https://github.com/mseclab/nathan "Nathan") (not updated since 2016)
 
 Please also verify the "Tools" section at the end of this book.
 
@@ -1271,6 +1271,7 @@ There are several open source tools for automated security analysis of an APK.
 - [QARK](https://github.com/linkedin/qark/ "QARK")
 - [Androbugs](https://github.com/AndroBugs/AndroBugs_Framework "Androbugs")
 - [JAADAS](https://github.com/flankerhqd/JAADAS "JAADAS")
+- [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF "MobSF")
 
 For enterprise tools, see the section "Static Source Code Analysis" in the chapter "Testing Tools."
 
@@ -1750,35 +1751,6 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 - Custom Trust - <https://developer.android.com/training/articles/security-config#CustomTrust>
 - Google Android Codelabs - <https://codelabs.developers.google.com/codelabs/android-network-security-config/#3>
 - Security Analyst’s Guide to Network Security Configuration in Android P - <https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/>
-
-#### Tools
-
-- Androbugs - <https://github.com/AndroBugs/AndroBugs_Framework>
-- Android-CertKiller - <https://github.com/51j0/Android-CertKiller>
-- Android tcpdump - <https://www.androidtcpdump.com/>
-- Android-SSL-TrustKiller - <https://github.com/iSECPartners/Android-SSL-TrustKiller>
-- Android Platform Tools - <https://developer.android.com/studio/releases/platform-tools.html>
-- Android Studio - <https://developer.android.com/studio/index.html>
 - Android developer documentation - <https://developer.android.com/studio/publish/app-signing#signing-manually>
 - Android 8.0 Behavior Changes - <https://developer.android.com/about/versions/oreo/android-8.0-changes>
 - Android 9.0 Behavior Changes - <https://developer.android.com/about/versions/pie/android-9.0-changes-all#device-security-changes>
-- apktool - <https://ibotpeaches.github.io/Apktool/>
-- apkx - <https://github.com/b-mueller/apkx>
-- Burp-non-HTTP-Extension - <https://github.com/summitt/Burp-Non-HTTP-Extension>
-- Burp Suite Professional - <https://portswigger.net/burp/>
-- Drozer - <https://labs.mwrinfosecurity.com/tools/drozer/>
-- Frida - <https://www.frida.re/docs/android/>
-- JAADAS - <https://github.com/flankerhqd/JAADAS>
-- Magisk Trust User Certs module - <https://github.com/NVISO-BE/MagiskTrustUserCerts/releases>
-- Mitm-relay - <https://github.com/jrmdev/mitm_relay>
-- Objection - <https://github.com/sensepost/objection>
-- OWASP ZAP - <https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project>
-- QARK - <https://github.com/linkedin/qark/>
-- Radare2 - <https://rada.re/r/>
-- R2frida - <https://github.com/nowsecure/r2frida/>
-- SDK tools - <https://developer.android.com/studio/index.html#downloads>
-- SSLUnpinning - <https://github.com/ac-pm/SSLUnpinning_Xposed>
-- Wireshark - <https://www.wireshark.org/>
-- MobSF - <https://github.com/MobSF/Mobile-Security-Framework-MobSF>
-- Nathan - <https://github.com/mseclab/nathan>
-- Xposed - <https://www.xda-developers.com/xposed-framework-hub/>

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -1764,3 +1764,45 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 - Android's .apk format - <https://en.wikipedia.org/wiki/Android_application_package>
 - Android remote sniffing using Tcpdump, nc and Wireshark - <https://blog.dornea.nu/2015/02/20/android-remote-sniffing-using-tcpdump-nc-and-wireshark/>
 - Wireless Client Isolation - <https://documentation.meraki.com/MR/Firewall_and_Traffic_Shaping/Wireless_Client_Isolation>
+
+#### Tools
+
+- adb - <https://developer.android.com/studio/command-line/adb>
+- Androbugs - <https://github.com/AndroBugs/AndroBugs_Framework>
+- Android Platform Tools - <https://developer.android.com/studio/releases/platform-tools.html>
+- Android Studio - <https://developer.android.com/studio/index.html>
+- Android tcpdump - <https://www.androidtcpdump.com/>
+- Android-CertKiller - <https://github.com/51j0/Android-CertKiller>
+- Android-SSL-TrustKiller - <https://github.com/iSECPartners/Android-SSL-TrustKiller>
+- angr - <https://github.com/angr/angr>
+- APK Extractor - <https://play.google.com/store/apps/details?id=com.ext.ui>
+- APKMirror - <https://apkmirror.com>
+- APKPure - <https://apkpure.com>
+- apktool - <https://ibotpeaches.github.io/Apktool/>
+- apkx - <https://github.com/b-mueller/apkx>
+- Burp Suite Professional - <https://portswigger.net/burp/>
+- Burp-non-HTTP-Extension - <https://github.com/summitt/Burp-Non-HTTP-Extension>
+- Capillary - <https://github.com/google/capillary>
+- Device File Explorer - <https://developer.android.com/studio/debug/device-file-explorer>
+- Drozer - <https://labs.mwrinfosecurity.com/tools/drozer/>
+- FileZilla - <https://filezilla-project.org/download.php>
+- Frida - <https://www.frida.re/docs/android/>
+- InsecureBankv2 - <https://github.com/dineshshetty/Android-InsecureBankv2>
+- Inspeckage - <https://github.com/ac-pm/Inspeckage>
+- JAADAS - <https://github.com/flankerhqd/JAADAS>
+- JustTrustMe - <https://github.com/Fuzion24/JustTrustMe>
+- Magisk Modules repository - <https://github.com/Magisk-Modules-Repo>
+- Magisk Trust User Certs module - <https://github.com/NVISO-BE/MagiskTrustUserCerts/releases>
+- Mitm-relay - <https://github.com/jrmdev/mitm_relay>
+- MobSF - <https://github.com/MobSF/Mobile-Security-Framework-MobSF>
+- Nathan - <https://github.com/mseclab/nathan>
+- Objection - <https://github.com/sensepost/objection>
+- OWASP ZAP - <https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project>
+- QARK - <https://github.com/linkedin/qark/>
+- R2frida - <https://github.com/nowsecure/r2frida/>
+- Radare2 - <https://rada.re/r/>
+- SDK tools - <https://developer.android.com/studio/index.html#downloads>
+- SSLUnpinning - <https://github.com/ac-pm/SSLUnpinning_Xposed>
+- Termux - <https://play.google.com/store/apps/details?id=com.termux>
+- Wireshark - <https://www.wireshark.org/>
+- Xposed - <https://www.xda-developers.com/xposed-framework-hub/>

--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -1738,16 +1738,16 @@ tmp-mksh: cat: /data/local/tmp/nowyouseeme: No such file or directory
 
 Voilà! The file "nowyouseeme" is now somewhat hidden from all usermode processes (note that you need to do a lot more to properly hide a file, including hooking stat(), access(), and other system calls).
 
-File-hiding is of course only the tip of the iceberg: you can accomplish a lot using kernel modules, including bypassing many root detection measures, integrity checks, and anti-debugging measures. You can find more examples in the "case studies" section of [Bernhard Mueller's Hacking Soft Tokens Paper](https://packetstormsecurity.com/files/138504/HITB_Hacking_Soft_Tokens_v1.2.pdf).
+File-hiding is of course only the tip of the iceberg: you can accomplish a lot using kernel modules, including bypassing many root detection measures, integrity checks, and anti-debugging measures. You can find more examples in the "case studies" section of Bernhard Mueller's Hacking Soft Tokens Paper [#mueller].
 
 ### References
 
-- Hacking Soft Tokens Paper - <https://packetstormsecurity.com/files/138504/HITB_Hacking_Soft_Tokens_v1.2.pdf>
 - Bionic - <https://github.com/android/platform_bionic>
 - Attacking Android Applications with Debuggers - <https://blog.netspi.com/attacking-android-applications-with-debuggers/>
 - Dynamic Malware Recompilation - <http://ieeexplore.ieee.org/document/6759227/>
 - Update on Development of Xposed for Nougat - <https://www.xda-developers.com/rovo89-updates-on-the-situation-regarding-xposed-for-nougat/>
 - Android Platform based Linux kernel rootkit - <http://phrack.org/issues/68/6.html>
+- [#mueller] Bernhard Mueller, Hacking Soft Tokens. Advanced Reverse Engineering on Android. - <https://packetstormsecurity.com/files/138504/HITB_Hacking_Soft_Tokens_v1.2.pdf>
 
 #### Tools
 

--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -1751,17 +1751,17 @@ File-hiding is of course only the tip of the iceberg: you can accomplish a lot u
 
 #### Tools
 
-- OWASP Mobile Testing Guide Crackmes - <https://github.com/OWASP/owasp-mstg/blob/master/Crackmes/>
-- JD - <http://jd.benow.ca/>
-- JAD - <http://www.javadecompilers.com/jad>
-- Procyon - <https://bitbucket.org/mstrobel/procyon/overview>
-- CFR - <http://www.benf.org/other/cfr/>
-- apkx - <https://github.com/b-mueller/apkx>
 - Android NDK Downloads - <https://developer.android.com/ndk/downloads/index.html#stable-downloads>
-- smalidea plugin for IntelliJ - <https://github.com/JesusFreke/smali/wiki/smalidea>
-- APKTool - <https://ibotpeaches.github.io/Apktool/>
-- Radare2 - <https://www.radare.org>
 - Angr - <https://angr.io/>
-- JEB Decompiler - <https://www.pnfsoftware.com>
+- APKTool - <https://ibotpeaches.github.io/Apktool/>
+- apkx - <https://github.com/b-mueller/apkx>
+- CFR - <http://www.benf.org/other/cfr/>
 - IDA Pro - <https://www.hex-rays.com/products/ida/>
+- JAD - <http://www.javadecompilers.com/jad>
+- JD - <http://jd.benow.ca/>
+- JEB Decompiler - <https://www.pnfsoftware.com>
+- OWASP Mobile Testing Guide Crackmes - <https://github.com/OWASP/owasp-mstg/blob/master/Crackmes/>
+- Procyon - <https://bitbucket.org/mstrobel/procyon/overview>
+- Radare2 - <https://www.radare.org>
+- smalidea plugin for IntelliJ - <https://github.com/JesusFreke/smali/wiki/smalidea>
 - VxStripper - <http://vxstripper.pagesperso-orange.fr>

--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -18,7 +18,7 @@ Make sure that the following is installed on your system:
 
 - The Android NDK. This is the Native Development Kit that contains prebuilt toolchains for cross-compiling native code for different architectures. See more details about the installation below.
 
-In addition to the SDK and NDK, you'll also need something to make Java bytecode more human-readable. Fortunately, Java decompilers generally handle Android bytecode well. Popular free decompilers include [JD](http://jd.benow.ca/ "JD"), [JAD](http://www.javadecompilers.com/jad "JAD"), [Procyon]( https://bitbucket.org/mstrobel/procyon/overview "Procyon"), and [CFR](http://www.benf.org/other/cfr/ "CFR"). For convenience, we have packed some of these decompilers into our [apkx wrapper script](https://github.com/b-mueller/apkx "apkx - APK Decompilation for the Lazy"). This script completely automates the process of extracting Java code from release APK files and makes it easy to experiment with different backends (we'll also use it in some of the following examples).
+In addition to the SDK and NDK, you'll also need something to make Java bytecode more human-readable. Fortunately, Java decompilers generally handle Android bytecode well. Popular free decompilers include [JD](http://jd.benow.ca/ "JD"), [JAD](http://www.javadecompilers.com/jad "JAD"), [Procyon](https://bitbucket.org/mstrobel/procyon/overview "Procyon"), and [CFR](http://www.benf.org/other/cfr/ "CFR"). For convenience, we have packed some of these decompilers into our [apkx wrapper script](https://github.com/b-mueller/apkx "apkx - APK Decompilation for the Lazy"). This script completely automates the process of extracting Java code from release APK files and makes it easy to experiment with different backends (we'll also use it in some of the following examples).
 
 Other tools are really a matter of preference and budget. A ton of free and commercial disassemblers, decompilers, and frameworks with different strengths and weaknesses exist; we'll cover some of them.
 
@@ -69,11 +69,11 @@ Although working with a completely free setup is possible, you should consider i
 
 ##### JEB
 
-[JEB](https://www.pnfsoftware.com "JEB Decompiler"), a commercial decompiler, packs all the functionality necessary for static and dynamic analysis of Android apps into an all-in-one package. It is reasonably reliable and includes prompt support. It has a built-in debugger, which allows for an efficient workflow—setting breakpoints directly in the decompiled (and annotated) sources is invaluable, especially with ProGuard-obfuscated bytecode. Of course, convenience like this doesn't come cheap, and now that JEB is provided fvia a subscription-based license, you'll have to pay a monthly fee to use it.
+[JEB](https://www.pnfsoftware.com "JEB Decompiler"), a commercial decompiler, packs all the functionality necessary for static and dynamic analysis of Android apps into an all-in-one package. It is reasonably reliable and includes prompt support. It has a built-in debugger, which allows for an efficient workflow—setting breakpoints directly in the decompiled (and annotated) sources is invaluable, especially with ProGuard-obfuscated bytecode. Of course, convenience like this doesn't come cheap, and now that JEB is provided via a subscription-based license, you'll have to pay a monthly fee to use it.
 
 ##### IDA Pro
 
-[IDA Pro]( https://www.hex-rays.com/products/ida/ "IDA Pro") is compatible with ARM, MIPS, Java bytecode, and, of course, Intel ELF binaries. It also comes with debuggers for both Java applications and native processes. With its powerful scripting, disassembling, and extension capabilities, IDA Pro works great for static analysis of native programs and libraries. However, the static analysis facilities it offers for Java code are rather basic—you get the Smali disassembly but not much more. You can't navigate the package and class structure, and some actions (such as renaming classes) can't performed, which can make working with more complex Java apps tedious.
+[IDA Pro](https://www.hex-rays.com/products/ida/ "IDA Pro") is compatible with ARM, MIPS, Java bytecode, and, of course, Intel ELF binaries. It also comes with debuggers for both Java applications and native processes. With its powerful scripting, disassembling, and extension capabilities, IDA Pro works great for static analysis of native programs and libraries. However, the static analysis facilities it offers for Java code are rather basic—you get the Smali disassembly but not much more. You can't navigate the package and class structure, and some actions (such as renaming classes) can't performed, which can make working with more complex Java apps tedious.
 
 ### Reverse Engineering
 
@@ -752,7 +752,7 @@ Execution traces can also be recorded in the standalone Android Device Monitor. 
 
 To start recording tracing information, select the target process in the "Devices" tab and click "Start Method Profiling". Click the stop button to stop recording, after which the Traceview tool will open and show the recorded trace. Clicking any of the methods in the profile panel highlights the selected method in the timeline panel.
 
-DDMS also offers a convenient heap dump button that will dump the Java heap of a process to a `.hprof` file. The Android Studio user guide contains more information about Traceview .
+DDMS also offers a convenient heap dump button that will dump the Java heap of a process to a `.hprof` file. The Android Studio user guide contains more information about Traceview.
 
 ###### Tracing System Calls
 
@@ -788,13 +788,13 @@ The KProbes interface provides an even more powerful way to instrument the kerne
 
 Jprobes and Kretprobes are other KProbes-based probe types that allow hooking of function entries and exits.
 
-The stock Android kernel comes without loadable module support, which is a problem because Kprobes are usually deployed as kernel modules. The strict memory protection the Android kernel is compiled with is another issue becauseit prevents the patching of some parts of Kernel memory. Elfmaster's system call hooking method causes a Kernel panic on stock Lollipop and Marshmallow because the sys_call_table is non-writable. You can, however, use KProbes in a sandbox by compiling your own, more lenient Kernel (more on this later).
+The stock Android kernel comes without loadable module support, which is a problem because Kprobes are usually deployed as kernel modules. The strict memory protection the Android kernel is compiled with is another issue because it prevents the patching of some parts of Kernel memory. Elfmaster's system call hooking method causes a Kernel panic on stock Lollipop and Marshmallow because the sys_call_table is non-writable. You can, however, use KProbes in a sandbox by compiling your own, more lenient Kernel (more on this later).
 
 ##### Emulation-based Analysis
 
 The Android emulator is based on QEMU, a generic and open source machine emulator. QEMU emulates a guest CPU by translating the guest instructions on-the-fly into instructions the host processor can understand. Each basic block of guest instructions is disassembled and translated into an intermediate representation called Tiny Code Generator (TCG). The TCG block is compiled into a block of host instructions, stored in a code cache, and executed. After execution of the basic block, QEMU repeats the process for the next block of guest instructions (or loads the already translated block from the cache). The whole process is called dynamic binary translation.
 
-Because the Android emulator is a fork of QEMU, it comes with all QEMU features, including monitoring, debugging, and tracing facilities. QEMU-specific parameters can be passed to the emulator with the -qemu command line flag. You can use QEMU's built-in tracing facilities to log executed instructions and virtual register values. Starting qemu with the "-d" command line flag will cause it to dump the blocks of guest code, micro operations, or host instructions being executed. With the –d_asm option, QEMU logs all basic blocks of guest code as they enter QEMU's translation function. The following command logs all translated blocks to a file:
+Because the Android emulator is a fork of QEMU, it comes with all QEMU features, including monitoring, debugging, and tracing facilities. QEMU-specific parameters can be passed to the emulator with the "-qemu" command line flag. You can use QEMU's built-in tracing facilities to log executed instructions and virtual register values. Starting qemu with the "-d" command line flag will cause it to dump the blocks of guest code, micro operations, or host instructions being executed. With the –d_asm option, QEMU logs all basic blocks of guest code as they enter QEMU's translation function. The following command logs all translated blocks to a file:
 
 ```shell
 $ emulator -show-kernel -avd Nexus_4_API_19 -snapshot default-boot -no-snapshot-save -qemu -d in_asm,cpu 2>/tmp/qemu.log
@@ -806,7 +806,7 @@ Dynamic analysis frameworks, such as PANDA and DroidScope, build on QEMU's traci
 
 ###### DroidScope
 
-DroidScope—an extension to the [DECAF dynamic analysis framework](https://github.com/sycurelab/DECAF)—is a malware analysis engine based on QEMU. It instrumentats the emulated environment on several context levels, making it possible to fully reconstruct the semantics on the hardware, Linux and Java levels.
+DroidScope (an extension to the [DECAF dynamic analysis framework](https://github.com/sycurelab/DECAF "DECAF dynamic analysis framework"))is a malware analysis engine based on QEMU. It instruments the emulated environment on several context levels, making it possible to fully reconstruct the semantics on the hardware, Linux and Java levels.
 
 DroidScope exports instrumentation APIs that mirror the different context levels (hardware, OS, and Java) of a real Android device. Analysis tools can use these APIs to query or set information and register callbacks for various events. For example, a plugin can register callbacks for native instruction start and end, memory reads and writes, register reads and writes, system calls, and Java method calls.
 
@@ -816,7 +816,7 @@ All of this makes it possible to build tracers that are practically transparent 
 
 [PANDA](https://github.com/moyix/panda/blob/master/docs/) is another QEMU-based dynamic analysis platform. Similar to DroidScope, PANDA can be extended by registering callbacks that are triggered by certain QEMU events. The twist PANDA adds is its record/replay feature. This allows an iterative workflow: the reverse engineer records an execution trace of the target app (or some part of it), then replays it repeatedly, refining the analysis plugins with each iteration.
 
-PANDA comes with pre-made plugins, including a stringsearch tool and a syscall tracer. Most importantly, it supports Android guests, and some of the DroidScope code has even been ported. Building and running PANDA for Android ("PANDROID") is relatively straightforward. To test it, clone Moiyx's git repository and build PANDA:
+PANDA comes with pre-made plugins, including a string search tool and a syscall tracer. Most importantly, it supports Android guests, and some of the DroidScope code has even been ported. Building and running PANDA for Android ("PANDROID") is relatively straightforward. To test it, clone Moiyx's git repository and build PANDA:
 
 ```shell
 $ cd qemu
@@ -827,7 +827,7 @@ As of this writing, Android versions up to 4.4.1 run fine in PANDROID, but anyth
 
 ##### VxStripper
 
-Another very useful tool built on QEMU is [VxStripper by Sébastien Josse](http://vxstripper.pagesperso-orange.fr). VXStripper is specifically designed for de-obfuscating binaries. By instrumenting QEMU's dynamic binary translation mechanisms, it dynamically extracts an intermediate representation of a binary. It then applies simplifications to the extracted intermediate representation and recompiles the simplified binary with LLVM. This is a very powerful way of normalizing obfuscated programs. See [Sébastien's paper](http://ieeexplore.ieee.org/document/6759227/ "Dynamic Malware Recompilation") for more information.
+Another very useful tool built on QEMU is [VxStripper by Sébastien Josse](http://vxstripper.pagesperso-orange.fr "VxStripper"). VXStripper is specifically designed for de-obfuscating binaries. By instrumenting QEMU's dynamic binary translation mechanisms, it dynamically extracts an intermediate representation of a binary. It then applies simplifications to the extracted intermediate representation and recompiles the simplified binary with LLVM. This is a very powerful way of normalizing obfuscated programs. See [Sébastien's paper](http://ieeexplore.ieee.org/document/6759227/ "Dynamic Malware Recompilation") for more information.
 
 ### Tampering and Runtime Instrumentation
 
@@ -1742,12 +1742,26 @@ File-hiding is of course only the tip of the iceberg: you can accomplish a lot u
 
 ### References
 
-- Hacking Soft Tokens Paper by Bernhard Mueller - <https://packetstormsecurity.com/files/138504/HITB_Hacking_Soft_Tokens_v1.2.pdf>
-- OWASP MSTG Crackmes - <https://github.com/OWASP/owasp-mstg/tree/master/Crackmes>
+- Hacking Soft Tokens Paper - <https://packetstormsecurity.com/files/138504/HITB_Hacking_Soft_Tokens_v1.2.pdf>
+- Bionic - <https://github.com/android/platform_bionic>
+- Attacking Android Applications with Debuggers - <https://blog.netspi.com/attacking-android-applications-with-debuggers/>
+- Dynamic Malware Recompilation - <http://ieeexplore.ieee.org/document/6759227/>
+- Update on Development of Xposed for Nougat - <https://www.xda-developers.com/rovo89-updates-on-the-situation-regarding-xposed-for-nougat/>
+- Android Platform based Linux kernel rootkit - <http://phrack.org/issues/68/6.html>
 
 #### Tools
 
-- Angr - <https://docs.angr.io>
-- Angro API Documenation -
+- OWASP Mobile Testing Guide Crackmes - <https://github.com/OWASP/owasp-mstg/blob/master/Crackmes/>
+- JD - <http://jd.benow.ca/>
+- JAD - <http://www.javadecompilers.com/jad>
+- Procyon - <https://bitbucket.org/mstrobel/procyon/overview>
+- CFR - <http://www.benf.org/other/cfr/>
 - apkx - <https://github.com/b-mueller/apkx>
-- Frida - <https://www.frida.re/docs/android/>
+- Android NDK Downloads - <https://developer.android.com/ndk/downloads/index.html#stable-downloads>
+- smalidea plugin for IntelliJ - <https://github.com/JesusFreke/smali/wiki/smalidea>
+- APKTool - <https://ibotpeaches.github.io/Apktool/>
+- Radare2 - <https://www.radare.org>
+- Angr - <https://angr.io/>
+- JEB Decompiler - <https://www.pnfsoftware.com>
+- IDA Pro - <https://www.hex-rays.com/products/ida/>
+- VxStripper - <http://vxstripper.pagesperso-orange.fr>

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -1484,26 +1484,12 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 
 ### References
 
+- Jailbreak Exploits - <https://www.theiphonewiki.com/wiki/Jailbreak_Exploits>
+- limera1n exploit - <https://www.theiphonewiki.com/wiki/Limera1n>
+- IPSW Downloads website - <https://ipsw.me>
+- Can I Jailbreak? - <https://canijailbreak.com/>
+- The iPhone Wiki - <https://www.theiphonewiki.com/>
+- Redmond Pie - <https://www.redmondpie.com/>
+- Reddit Jailbreak - <https://www.reddit.com/r/jailbreak/>
+- Information Property List - <https://developer.apple.com/documentation/bundleresources/information_property_list?language=objc>
 - UIDeviceFamily - <https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11>
-
-#### Tools
-
-- Burp Suite - <https://portswigger.net/burp/communitydownload>
-- Class-dump - <https://github.com/interference-security/ios-pentest-tools/blob/master/class-dump>
-- Class-dump-z - <https://github.com/interference-security/ios-pentest-tools/blob/master/class-dump-z>
-- Clutch - <https://github.com/KJCracks/Clutch>
-- Frida - <https://www.frida.re>
-- Frida-ios-dump - <https://github.com/AloneMonkey/frida-ios-dump>
-- IDB - <https://www.idbtool.com>
-- Introspy - <https://github.com/iSECPartners/Introspy-iOS>
-- ipainstaller - <https://github.com/autopear/ipainstaller>
-- iProxy - <https://iphonedevwiki.net/index.php/SSH_Over_USB>
-- Keychain-dumper - <https://github.com/ptoomey3/Keychain-Dumper/>
-- MobSF - <https://github.com/MobSF/Mobile-Security-Framework-MobSF>
-- Needle - <https://github.com/mwrlabs/needle>
-- Objection - <https://github.com/sensepost/objection>
-- Reverse Engineering tools for iOS Apps - <http://iphonedevwiki.net/index.php/Reverse_Engineering_Tools>
-- SSL Kill Switch 2 - <https://github.com/nabla-c0d3/ssl-kill-switch2>
-- Usbmuxd - <https://github.com/libimobiledevice/usbmuxd>
-- Wireshark - <https://www.wireshark.org/download.html>
-- Xcode - <https://developer.apple.com/xcode/>

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -1493,3 +1493,38 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 - Reddit Jailbreak - <https://www.reddit.com/r/jailbreak/>
 - Information Property List - <https://developer.apple.com/documentation/bundleresources/information_property_list?language=objc>
 - UIDeviceFamily - <https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW11>
+
+#### Tools
+
+- Apple iOS SDK - <https://developer.apple.com/download/more/>
+- AppSync - <http://repo.hackyouriphone.org/appsyncunified>
+- Burp Suite - <https://portswigger.net/burp/communitydownload>
+- Chimera - <https://chimera.sh/>
+- Class-dump - <https://github.com/interference-security/ios-pentest-tools/blob/master/class-dump>
+- Class-dump-z - <https://github.com/interference-security/ios-pentest-tools/blob/master/class-dump-z>
+- Clutch - <https://github.com/KJCracks/Clutch>
+- Cydia Impactor - <http://www.cydiaimpactor.com/>
+- Frida - <https://www.frida.re>
+- Frida-ios-dump - <https://github.com/AloneMonkey/frida-ios-dump>
+- Ghidra - <https://ghidra-sre.org/>
+- IDB - <https://www.idbtool.com>
+- iFunBox - <http://www.i-funbox.com/>
+- Introspy - <https://github.com/iSECPartners/Introspy-iOS>
+- ios-deploy - <https://github.com/ios-control/ios-deploy>
+- IPA Installer Console - <https://cydia.saurik.com/package/com.autopear.installipa>
+- ipainstaller - <https://github.com/autopear/ipainstaller>
+- iProxy - <https://iphonedevwiki.net/index.php/SSH_Over_USB>
+- ITMS services asset downloader - <https://www.npmjs.com/package/itms-services>
+- Keychain-dumper - <https://github.com/ptoomey3/Keychain-Dumper/>
+- libimobiledevice - <https://www.libimobiledevice.org/>
+- MobSF - <https://github.com/MobSF/Mobile-Security-Framework-MobSF>
+- Needle - <https://github.com/mwrlabs/needle>
+- Objection - <https://github.com/sensepost/objection>
+- Passionfruit - <https://github.com/chaitin/passionfruit/>
+- Radare2 - <https://github.com/radare/radare2>
+- Sileo - <https://cydia-app.com/sileo/>
+- SSL Kill Switch 2 - <https://github.com/nabla-c0d3/ssl-kill-switch2>
+- TablePlus - <https://tableplus.io/>
+- Usbmuxd - <https://github.com/libimobiledevice/usbmuxd>
+- Wireshark - <https://www.wireshark.org/download.html>
+- Xcode - <https://developer.apple.com/xcode/>

--- a/Document/0x06c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x06c-Reverse-Engineering-and-Tampering.md
@@ -502,7 +502,7 @@ PID  Name
 
 #### Troubleshooting
 
-When something goes wrong (and it usually does), mismatches between the provisioning profile and code-signing header are the most likely causes. Reading the [official documentation](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/MaintainingProfiles/MaintainingProfiles.html "Maintaining Provisioning Profiles") helps you understand the code-signing process. Apple's [entitlement troubleshooting page](https://developer.apple.com/library/content/technotes/tn2415/_index.html "Entitlements Troubleshooting") is also a useful resource.
+When something goes wrong (and it usually does), mismatches between the provisioning profile and code-signing header are the most likely causes. Reading the [official documentation](https://developer.apple.com/support/code-signing/ "Code Signing") helps you understand the code-signing process. Apple's [entitlement troubleshooting page](https://developer.apple.com/library/content/technotes/tn2415/_index.html "Entitlements Troubleshooting") is also a useful resource.
 
 ### Method Tracing with Frida
 
@@ -618,3 +618,33 @@ Use the following approach to patch the JavaScript file:
 4. Identify the code in the temporary file that should be patched and patch it.
 5. Put the *patched code* on a single line and copy it into the original `Payload/[APP].app/main.jsbundle` file.
 6. Close and restart the application.
+
+### References
+
+- Apple's Entitlements Troubleshooting - <https://developer.apple.com/library/content/technotes/tn2415/_index.html>
+- Apple's Code Signing - <https://developer.apple.com/support/code-signing/>
+- iOS Instrumentation without Jailbreak - <https://www.nccgroup.trust/au/about-us/newsroom-and-events/blogs/2016/october/ios-instrumentation-without-jailbreak/>
+- Frida iOS Tutorial - <https://www.frida.re/docs/ios/>
+- Frida iOS Examples - <https://www.frida.re/docs/examples/ios/>
+
+#### Tools
+
+- Reverse Engineering tools for iOS Apps - <http://iphonedevwiki.net/index.php/Reverse_Engineering_Tools>
+- Cycript - <http://www.cycript.org/>
+- Class-dump - <http://stevenygard.com/projects/class-dump/>
+- Class-dump-z - <https://code.google.com/archive/p/networkpx/wikis/class_dump_z.wiki>
+- Class-dump-dyld - <https://github.com/limneos/classdump-dyld/>
+- MachoOView - <https://sourceforge.net/projects/machoview/>
+- Radare2 - <https://rada.re/r/>
+- Hopper - <https://www.hopperapp.com/>
+- IPA Installer Console - <https://cydia.saurik.com/package/com.autopear.installipa/>
+- ipainstaller - <https://cydia.saurik.com/package/com.slugrail.ipainstaller/>
+- Hopper Disassembler - <https://www.hopperapp.com/>
+- Optool - <https://github.com/alexzielenski/optool>
+- ios-deploy - <https://github.com/phonegap/ios-deploy>
+- Xcode command line developer tools - <https://railsapps.github.io/xcode-command-line-tools.html>
+- Frida - <https://www.frida.re>
+- Objection - <https://github.com/sensepost/objection>
+- Swizzler project - <https://github.com/vtky/Swizzler2/>
+- OWASP UnCrackable Apps for iOS - <https://github.com/OWASP/owasp-mstg/tree/master/Crackmes#ios>
+- Damn Vulnerable iOS App - <http://damnvulnerableiosapp.com/>

--- a/Document/0x06c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x06c-Reverse-Engineering-and-Tampering.md
@@ -629,22 +629,22 @@ Use the following approach to patch the JavaScript file:
 
 #### Tools
 
-- Reverse Engineering tools for iOS Apps - <http://iphonedevwiki.net/index.php/Reverse_Engineering_Tools>
-- Cycript - <http://www.cycript.org/>
 - Class-dump - <http://stevenygard.com/projects/class-dump/>
-- Class-dump-z - <https://code.google.com/archive/p/networkpx/wikis/class_dump_z.wiki>
 - Class-dump-dyld - <https://github.com/limneos/classdump-dyld/>
-- MachoOView - <https://sourceforge.net/projects/machoview/>
-- Radare2 - <https://rada.re/r/>
+- Class-dump-z - <https://code.google.com/archive/p/networkpx/wikis/class_dump_z.wiki>
+- Cycript - <http://www.cycript.org/>
+- Damn Vulnerable iOS App - <http://damnvulnerableiosapp.com/>
+- Frida - <https://www.frida.re>
 - Hopper - <https://www.hopperapp.com/>
+- Hopper Disassembler - <https://www.hopperapp.com/>
+- ios-deploy - <https://github.com/phonegap/ios-deploy>
 - IPA Installer Console - <https://cydia.saurik.com/package/com.autopear.installipa/>
 - ipainstaller - <https://cydia.saurik.com/package/com.slugrail.ipainstaller/>
-- Hopper Disassembler - <https://www.hopperapp.com/>
-- Optool - <https://github.com/alexzielenski/optool>
-- ios-deploy - <https://github.com/phonegap/ios-deploy>
-- Xcode command line developer tools - <https://railsapps.github.io/xcode-command-line-tools.html>
-- Frida - <https://www.frida.re>
+- MachoOView - <https://sourceforge.net/projects/machoview/>
 - Objection - <https://github.com/sensepost/objection>
-- Swizzler project - <https://github.com/vtky/Swizzler2/>
+- Optool - <https://github.com/alexzielenski/optool>
 - OWASP UnCrackable Apps for iOS - <https://github.com/OWASP/owasp-mstg/tree/master/Crackmes#ios>
-- Damn Vulnerable iOS App - <http://damnvulnerableiosapp.com/>
+- Radare2 - <https://rada.re/r/>
+- Reverse Engineering tools for iOS Apps - <http://iphonedevwiki.net/index.php/Reverse_Engineering_Tools>
+- Swizzler project - <https://github.com/vtky/Swizzler2/>
+- Xcode command line developer tools - <https://railsapps.github.io/xcode-command-line-tools.html>


### PR DESCRIPTION
This PR removes the "#### Tools" sections at the bottom of both chapters 0x5b/6b
- done after checking that are referenced before.
- some links were moved to "References" as they are not tools anyway.
- all other missing "References" were also added to these chapters.
- if we would keep this list we would have to sync it constantly as the chapter changes and if we add more recommended tools in the "Recommended tools" section. 
- the "Recommended tools" section should serve as an overview of the recommended tools.
- other tools are not part of the "Recommended tools" section but they are mentioned inline, which is sufficient I would say. In case not, I would rather include them in the "Recommended tools" section.

In addition, this PR adds the missing Tools and references in 0x5c and 0x6c and fixes several typos, one dead link and several extra whitespaces in links.