### PR TITLE
Drop Burp-Non-HTTP-Extension

### DIFF
--- a/Document/0x04f-Testing-Network-Communication.md
+++ b/Document/0x04f-Testing-Network-Communication.md
@@ -22,7 +22,6 @@ Using a proxy breaks SSL certificate verification and the app will usually fail 
 
 Interception proxies such as Burp and OWASP ZAP won't show non-HTTP traffic, because they aren't capable of decoding it properly by default. There are, however, Burp plugins available such as:
 
-- [Burp-non-HTTP-Extension](https://github.com/summitt/Burp-Non-HTTP-Extension) and
 - [Mitm-relay](https://github.com/jrmdev/mitm_relay).
 
 These plugins can visualize non-HTTP protocols and you will also be able to intercept and manipulate the traffic.
@@ -268,7 +267,7 @@ Verify that the server or termination proxy at which the HTTPS connection termin
 Intercept the tested app's incoming and outgoing network traffic and make sure that this traffic is encrypted. You can intercept network traffic in any of the following ways:
 
 - Capture all HTTP(S) and Websocket traffic with an interception proxy like OWASP ZAP or Burp Suite and make sure all requests are made via HTTPS instead of HTTP.
-- Interception proxies like Burp and OWASP ZAP will show HTTP(S) traffic only. You can, however, use a Burp plugin such as [Burp-non-HTTP-Extension](https://github.com/summitt/Burp-Non-HTTP-Extension) or the tool [mitm-relay](https://github.com/jrmdev/mitm_relay) to decode and visualize communication via XMPP and other protocols.
+- Interception proxies like Burp and OWASP ZAP will show HTTP(S) traffic only. You can, however, use a Burp plugin such as [mitm-relay](https://github.com/jrmdev/mitm_relay) to decode and visualize communication via XMPP and other protocols.
 
 > Some applications may not work with proxies like Burp and ZAP because of Certificate Pinning. In such a scenario, please check "Testing Custom Certificate Stores and SSL Pinning".
 

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -1805,7 +1805,6 @@ For information on disabling SSL Pinning both statically and dynamically, refer 
 - apktool - <https://ibotpeaches.github.io/Apktool/>
 - apkx - <https://github.com/b-mueller/apkx>
 - Burp Suite Professional - <https://portswigger.net/burp/>
-- Burp-non-HTTP-Extension - <https://github.com/summitt/Burp-Non-HTTP-Extension>
 - Capillary - <https://github.com/google/capillary>
 - Device File Explorer - <https://developer.android.com/studio/debug/device-file-explorer>
 - Drozer - <https://labs.mwrinfosecurity.com/tools/drozer/>


### PR DESCRIPTION
NoPE Proxy doesn't appear to be maintained anymore.

Bug: https://github.com/summitt/Burp-Non-HTTP-Extension/issues/35

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
