### PR TITLE
removed arch-2 for xss

### DIFF
--- a/Document/0x04h-Testing-Code-Quality.md
+++ b/Document/0x04h-Testing-Code-Quality.md
@@ -91,7 +91,7 @@ Verify that the following best practices have been followed:
 
 We will cover details related to input sources and potentially vulnerable APIs for each mobile OS in the OS-specific testing guides.
 
-### Cross-Site Scripting Flaws (MSTG-ARCH-2 and MSTG-PLATFORM-2)
+### Cross-Site Scripting Flaws (MSTG-PLATFORM-2)
 
 Cross-site scripting (XSS) issues allow attackers to inject client-side scripts into web pages viewed by users. This type of vulnerability is prevalent in web applications. When a user views the injected script in a browser, the attacker gains the ability to bypass the same origin policy, enabling a wide variety of exploits (e.g. stealing session cookies, logging key presses, performing arbitrary actions, etc.).
 


### PR DESCRIPTION
Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

No PR. 
Jeroen found it during review and ARCH-2 should be removed from XSS.
