### PR TITLE
Clarify access token renewal code example

### DIFF
--- a/Document/0x04e-Testing-Authentication-and-Session-Management.md
+++ b/Document/0x04e-Testing-Authentication-and-Session-Management.md
@@ -397,11 +397,11 @@ A common method of granting tokens combines [access tokens and refresh tokens](h
 For apps that handle sensitive data, make sure that the refresh token expires after a reasonable period of time. The following example code shows a refresh token API that checks the refresh token's issue date. If the token is not older than 14 days, a new access token is issued. Otherwise, access is denied and the user is prompted to login again.
 
 ```Java
- app.post('/refresh_token', function (req, res) {
-  // verify the existing token
+ app.post('/renew_access_token', function (req, res) {
+  // verify the existing refresh token
   var profile = jwt.verify(req.body.token, secret);
 
-  // if more than 14 days old, force login
+  // if refresh token is more than 14 days old, force login
   if (profile.original_iat - new Date() > 14) { // iat == issued at
     return res.send(401); // re-login
   }
@@ -409,9 +409,9 @@ For apps that handle sensitive data, make sure that the refresh token expires af
   // check if the user still exists or if authorization hasn't been revoked
   if (!valid) return res.send(401); // re-logging
 
-  // issue a new token
-  var refreshed_token = jwt.sign(profile, secret, { expiresInMinutes: 60*5 });
-  res.json({ token: refreshed_token });
+  // issue a new access token
+  var renewed_access_token = jwt.sign(profile, secret, { expiresInMinutes: 60*5 });
+  res.json({ token: renewed_access_token });
 });
 ```
 


### PR DESCRIPTION
This pull request aims to make some small changes to the token renewal example. It adjusts the example endpoint & variable names, plus the example code comments, to more clearly articulate the idea that a refresh token is being provided into the request to retrieve a fresh, short-lived access token.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #< insert number here >.
