### PR TITLE
introduce FileDP tool for Data Protection Class verification

### DIFF
--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -332,6 +332,14 @@ To use Needle to read the Keychain, execute the following command:
 [needle][keychain_dump] > run
 ```  
 
+###### Validate the Data Protection Classes
+You can use FileDP module in order to verify Data protection class of the file or directory:
+
+``` shell
+[needle] > use storage/data/FileDP
+[needle][FileDP] > run
+```
+
 ###### Searching for Binary Cookies
 
 iOS applications often store binary cookie files in the application sandbox. Cookies are binary files containing cookie data for application WebViews. You can use Needle to convert these files to a readable format and inspect the data. Use the following Needle module, which searches for binary cookie files stored in the application container, lists their data protection values, and gives the user the options to inspect or download the file:


### PR DESCRIPTION
```- [ ] You verified/tested the effectiveness of your contribution```
👆 This part is especially funny because Needle framework is pretty abandoned and supports only iOS 8, 9 and 10 and most modules support only 32 bit devices. Rather then enhancing `Dynamic Analyse with Needle` section we'd better consider replacing it with dynamic analyse with separate tools that once were included as modules into Needle.

This PR contains only a mention that Data protection class of a file can be verified during dynamic analysis. Hope interested reader will find her way to run `FileDP` on modern devices with modern jailbreaks.