### PR TITLE
Update writeup_Diving_into_mobile_cryptography_using_dynamic_instrume…

### DIFF
--- a/Crackmes/Write-ups/OMTG-Android-App/writeup_Diving_into_mobile_cryptography_using_dynamic_instrumentation_with_frida.md
+++ b/Crackmes/Write-ups/OMTG-Android-App/writeup_Diving_into_mobile_cryptography_using_dynamic_instrumentation_with_frida.md
@@ -148,8 +148,7 @@ With the terminal pointing to the directory where this files is we will run the 
 
 `frida -U sg.vp.owasp_mobile.OMTG_Android -l hook_decryptString.js`
 
-The Frida CLI will open, connect to the device (`-U`) and will load the script (`-l`).
-The Frida CLI will open, connect to the test device over USB (`-U`), target a specific application under test (`sg.vp.owasp_mobile.OMTG_Android`) & load load the hooking script (`-l`).
+The Frida CLI will open, connect to the test device over USB (`-U`), target a specific application under test (`sg.vp.owasp_mobile.OMTG_Android`) and load the hooking script (`-l`).
 
 From now on, every time we click on **decrypt** it will print a log as indicated in our script.
 

--- a/Crackmes/Write-ups/OMTG-Android-App/writeup_Diving_into_mobile_cryptography_using_dynamic_instrumentation_with_frida.md
+++ b/Crackmes/Write-ups/OMTG-Android-App/writeup_Diving_into_mobile_cryptography_using_dynamic_instrumentation_with_frida.md
@@ -23,6 +23,12 @@ We have learnt:
 
 We will work with the [OMTG app][OMTGApp]. For this to work we will use Android 5 and Android 7 because they use different Java classes to handle the private keys.
 
+>Note: frida CLI and frida-server versions must match
+
+The specific version of frida tooling that you've installed on your workstation must match the version of frida-server that you download and push to your test device. 
+  
+This guide is written to expect alignment at `11.0.3`. Substitute `11.0.3` with your specific version as needed.
+
 ### Android 5
 
 - Create a virtual device with the following parameters:
@@ -143,6 +149,7 @@ With the terminal pointing to the directory where this files is we will run the 
 `frida -U sg.vp.owasp_mobile.OMTG_Android -l hook_decryptString.js`
 
 The Frida CLI will open, connect to the device (`-U`) and will load the script (`-l`).
+The Frida CLI will open, connect to the test device over USB (`-U`), target a specific application under test (`sg.vp.owasp_mobile.OMTG_Android`) & load load the hooking script (`-l`).
 
 From now on, every time we click on **decrypt** it will print a log as indicated in our script.
 


### PR DESCRIPTION
…ntation_with_frida.md

Add note regarding requirement for the local workstation's version of frida version to match the version of frida-server that is pushed to the test device that's hosting the application under test (emulator). 

It is possible for newer readers of the MSTG & this writeup to have set up their workstation after this content was written, and so have mismatching frida / frida-server versions. As this writeup is very clear in referencing specific versions of source or built artifacts in some sections, including specific frida-server version detail could be off-putting for newer readers.

Also, add some minor explanation to the frida command description that connects to the test device, specifies the application under test and loads the hooking script.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #< insert number here >.
