### PR TITLE
Remove old instruction for APK Debugging

### DIFF
--- a/Document/0x05c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x05c-Reverse-Engineering-and-Tampering.md
@@ -1175,9 +1175,7 @@ To _convert_ a release build into a debuggable build, you need to modify a flag 
 ```xml
 <application android:allowBackup="true" android:debuggable="true" android:icon="@drawable/ic_launcher" android:label="@string/app_name" android:name="com.xxx.xxx.xxx" android:theme="@style/AppTheme">
 ```
-
-Note: To get `apktool` to do this for you automatically, use the `-d` or `--debug` flag while building the APK. This will add `android:debuggable="true"` to the Android Manifest.
-
+Android
 Even if we haven't altered the source code, this modification also breaks the APK signature, so you'll also have to re-sign the altered APK archive.
 
 ##### Repackaging


### PR DESCRIPTION
Since https://github.com/iBotPeaches/Apktool/issues/1061 (2015)

Apktool no longer supports these options.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [✔️ ] Your contribution is written in the 2nd person (e.g. you)
- [✔️ ] Your contribution is written in an active present form for as much as possible.
- [ ✔️] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ✔️] Your contribution has proper formatted markdown and/or code
- [ ✔️] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ✔️] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR covers issue #< insert number here >.
