### PR TITLE
Add info to set 'Support invisible proxy' in 0x04f-Testing-Network-Communication.md

### DIFF
--- a/Document/0x04f-Testing-Network-Communication.md
+++ b/Document/0x04f-Testing-Network-Communication.md
@@ -149,6 +149,8 @@ When testing a Xamarin app and when you are trying to set the system proxy in th
     $ sudo iptables -t nat -A PREROUTING -p tcp --dport 443 -j DNAT --to-destination 127.0.0.1:8080 
     ```
 
+In Burp you need to set the option 'Support invisible proxy' in the listener settings.
+
 - Instead of bettercap an alternative is tweaking the `/etc/hosts` on the mobile phone. Add an entry into `/etc/hosts` for the target domain and point it to the IP address of your intercepting proxy. This creates a similar situation of being MiTM as with bettercap and you need to redirect port 443 to the port which is used by your interception proxy. The redirection can be applied as mentioned above. Additionally, you need to redirect traffic from your interception proxy to the original location and port.
 
 > When redirecting traffic you should create narrow rules to the domains and IPs in scope, to minimize noise and out-of-scope traffic.

--- a/Document/0x04f-Testing-Network-Communication.md
+++ b/Document/0x04f-Testing-Network-Communication.md
@@ -149,7 +149,7 @@ When testing a Xamarin app and when you are trying to set the system proxy in th
     $ sudo iptables -t nat -A PREROUTING -p tcp --dport 443 -j DNAT --to-destination 127.0.0.1:8080 
     ```
 
-In Burp you need to set the option 'Support invisible proxy' in the listener settings.
+  As last step, you need to set the option 'Support invisible proxy' in the listener settings of Burp Suite.
 
 - Instead of bettercap an alternative is tweaking the `/etc/hosts` on the mobile phone. Add an entry into `/etc/hosts` for the target domain and point it to the IP address of your intercepting proxy. This creates a similar situation of being MiTM as with bettercap and you need to redirect port 443 to the port which is used by your interception proxy. The redirection can be applied as mentioned above. Additionally, you need to redirect traffic from your interception proxy to the original location and port.
 


### PR DESCRIPTION
Add info to set 'Support invisible proxy' in 0x04f-Testing-Network-Communication.md to section regarding bettercap.
This PR covers issue #1591.
