### PR TITLE
fix linking between PRs and issues

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Pl
 - [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
 
 If your PR is related to an issue. Please end your PR test with the following line:
-This PR covers issue #< insert number here >.
+This PR closes #< insert number here >.


### PR DESCRIPTION
Until now we were missing a nice feature of GitHub: the linking between PRs and the issues related. With this change we'll be able to map PRs the the issues they close. And the issues will be closed only if the PR is merged to master. And this will happen automatically.