### PR TITLE
Updated OWASP Mobile Top 10 links to point to the new website.

### DIFF
--- a/Document-ru/0x06e-Testing-Cryptography.md
+++ b/Document-ru/0x06e-Testing-Cryptography.md
@@ -57,7 +57,7 @@ int result = SecRandomCopyBytes(kSecRandomDefault, 16, randomBytes);
 ### Ссылки
 
 #### OWASP Mobile Top 10 2016
-- M5 - Недостаточная криптография - https://www.owasp.org/index.php/Mobile_Top_10_2016-M5-Insufficient_Cryptography
+- M5 - Недостаточная криптография - https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography
 
 #### OWASP MASVS
 - V3.3: "Приложение использует криптографические примитивы, которые подходят для конкретного прецедента, с параметрами, которые соответствуют лучшим практикам отрасли."

--- a/Document-ru/0x06f-Testing-Local-Authentication.md
+++ b/Document-ru/0x06f-Testing-Local-Authentication.md
@@ -224,7 +224,7 @@ Needle также может использоваться, чтобы обойт
 
 #### OWASP Mobile Top 10 2016
 
-- M4 - Небезопасная аутентификация - https://www.owasp.org/index.php/Mobile_Top_10_2016-M4-Insecure_Authentication
+- M4 - Небезопасная аутентификация - https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication
 
 #### OWASP MASVS
 

--- a/Document-ru/0x06g-Testing-Network-Communication.md
+++ b/Document-ru/0x06g-Testing-Network-Communication.md
@@ -226,7 +226,7 @@ else {
 
 ##### OWASP Mobile Top 10 2016
 
-- M3 - Недостаточная защита транспортного протокола - https://www.owasp.org/index.php/Mobile_Top_10_2014-M3
+- M3 - Недостаточная защита транспортного протокола - https://owasp.org/www-project-mobile-top-10/2014-risks/m3-insufficient-transport-layer-protection
 
 ##### OWASP MASVS
 

--- a/Document-ru/0x06h-Testing-Platform-Interaction.md
+++ b/Document-ru/0x06h-Testing-Platform-Interaction.md
@@ -197,7 +197,7 @@ WebViews могут загружать удаленный контент или 
 
 #### OWASP Mobile Top 10 2016
 
-- M7 - Инъекция на стороне клиента - https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality
+- M7 - Инъекция на стороне клиента - https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality
 
 #### OWASP MASVS
 

--- a/Document-ru/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document-ru/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -366,7 +366,7 @@ IDB автоматизирует процесс проверки сразу дл
 
 #### OWASP Mobile Top 10 2016
 
-- M7 - Качество кода на стороне клиента - <https://www.owasp.org/index.php/Mobile_Top_10_2016-M7-Poor_Code_Quality>
+- M7 - Качество кода на стороне клиента - <https://owasp.org/www-project-mobile-top-10/2016-risks/m7-client-code-quality>
 
 #### OWASP MASVS
 

--- a/Document-ru/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document-ru/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -604,7 +604,7 @@ int xyz(char *dst) {
 
 #### OWASP Mobile Top 10 2016
 
--	M9 - Обратное проектирование - https://www.owasp.org/index.php/Mobile_Top_10_2016-M9-Reverse_Engineering
+-	M9 - Обратное проектирование - https://owasp.org/www-project-mobile-top-10/2016-risks/m9-reverse-engineering
 
 #### OWASP MASVS
 

--- a/Templates/testcase.md
+++ b/Templates/testcase.md
@@ -20,7 +20,7 @@
 ##### OWASP Mobile Top 10 2016
 
 - MX - Title - Link
-- M3 - Insufficient Transport Layer Protection - https://www.owasp.org/index.php/Mobile_Top_10_2014-M3
+- M3 - Insufficient Transport Layer Protection - https://owasp.org/www-project-mobile-top-10/2014-risks/m3-insufficient-transport-layer-protection
 
 ##### OWASP MASVS
 


### PR DESCRIPTION

It appears only the Russian version of the MSTG still had links to the OWASP Mobile Top 10 website, but as I just updated the OWASP Mobile Top 10 website I thought I would help update links found in the MSTG and MASVS.

Thanks! 