### PR TITLE
Fix wrong reference title SSL->Certificate

### DIFF
--- a/Document/0x04f-Testing-Network-Communication.md
+++ b/Document/0x04f-Testing-Network-Communication.md
@@ -436,7 +436,7 @@ Intercept the tested app's incoming and outgoing network traffic and make sure t
 - Capture all HTTP(S) and Websocket traffic with an interception proxy like OWASP ZAP or Burp Suite and make sure all requests are made via HTTPS instead of HTTP.
 - Interception proxies like Burp and OWASP ZAP will show HTTP(S) traffic only. You can, however, use a Burp plugin such as [Burp-non-HTTP-Extension](https://github.com/summitt/Burp-Non-HTTP-Extension "Burp-non-HTTP-Extension") or the tool [mitm-relay](https://github.com/jrmdev/mitm_relay "mitm-relay") to decode and visualize communication via XMPP and other protocols.
 
-> Some applications may not work with proxies like Burp and ZAP because of Certificate Pinning. In such a scenario, please check "Testing Custom Certificate Stores and SSL Pinning".
+> Some applications may not work with proxies like Burp and ZAP because of Certificate Pinning. In such a scenario, please check "Testing Custom Certificate Stores and Certificate Pinning".
 
 If you want to verify whether your server supports the right cipher suites, there are various tools you can use:
 

--- a/Document/0x05h-Testing-Platform-Interaction.md
+++ b/Document/0x05h-Testing-Platform-Interaction.md
@@ -1020,7 +1020,7 @@ To address these attack vectors, check the following:
 - The HTTPS communication must be implemented according to best practices to avoid MITM attacks. This means:
   - all communication is encrypted via TLS (see test case "Testing for Unencrypted Sensitive Data on the Network"),
   - the certificate is checked properly (see test case "Testing Endpoint Identify Verification"), and/or
-  - the certificate should be pinned (see "Testing Custom Certificate Stores and SSL Pinning").
+  - the certificate should be pinned (see "Testing Custom Certificate Stores and Certificate Pinning").
 
 ### Testing WebView Protocol Handlers (MSTG-PLATFORM-6)
 


### PR DESCRIPTION
Testing Custom Certificate Stores and Certificate Pinning (MSTG-NETWORK-4) section was referenced but the title was wrong.

Before: Some applications may not work with proxies like Burp and ZAP because of Certificate Pinning. In such a scenario, please check "Testing Custom Certificate Stores and SSL Pinning".
After: Some applications may not work with proxies like Burp and ZAP because of Certificate Pinning. In such a scenario, please check "Testing Custom Certificate Stores and Certificate Pinning".

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #< insert number here >.
