### PR TITLE
Correct MarkDown syntax error in the section 'Android Basic Security …

### DIFF
--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -1852,7 +1852,7 @@ There are different configurations available for the Network Security Configurat
 ```xml
 <certificates src=["system" | "user" | "raw resource"]
               overridePins=["true" | "false"] />
-
+```
 
 Each certificate can be one of the following:
 - a "raw resource" ID pointing to a file containing X.509 certificates


### PR DESCRIPTION
…Testing'

Just corrected a little MarkDown syntax error, because this book is perfect, and shouldn't contain syntax errors.  
I haven't seen a book this awesome from long time ago, just perfect.

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)