### PR TITLE
Fix cocoapods

### DIFF
--- a/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -219,7 +219,7 @@ $ pod install
 Next, now that the dependency tree has been built, you can create an overview of the dependencies and their versions by running the following commands:
 
 ```shell
-$ sudo gem install cocoapods-dependencies
+$ sudo gem install CocoaPods-dependencies
 $ pod dependencies
 ```
 

--- a/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -219,7 +219,7 @@ $ pod install
 Next, now that the dependency tree has been built, you can create an overview of the dependencies and their versions by running the following commands:
 
 ```shell
-$ sudo gem install CocoaPods-dependencies
+$ sudo gem install cocoapods-dependencies
 $ pod dependencies
 ```
 


### PR DESCRIPTION
need to be lowercase:

```
$ sudo gem install CocoaPods-dependencies
Password:
Sorry, try again.
Password:
ERROR:  Could not find a valid gem 'CocoaPods-dependencies' (>= 0) in any repository
ERROR:  Possible alternatives: cocoapods-dependencies
```