### PR TITLE
added iPhoneWiki link for ssh over usb

### DIFF
--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -529,6 +529,8 @@ root@localhost's password:
 iPhone:~ root#
 ```
 
+You can [make the iproxy run automatically in the background](https://iphonedevwiki.net/index.php/SSH_Over_USB "Making iproxy run automatically in the background on OS X") if you don't want to run the binary every time you want to SSH over USB.
+
 You can also connect to your iPhone's USB via [Needle](https://labs.mwrinfosecurity.com/blog/needle-how-to/ "Needle").
 
 ##### On-device Shell App

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -521,7 +521,7 @@ $ iproxy 2222 22
 waiting for connection
 ```
 
-The above command maps port `22` on the iOS device to port `2222` on localhost. You can also [make the iproxy run automatically in the background](https://iphonedevwiki.net/index.php/SSH_Over_USB "Making iproxy run automatically in the background on OS X") if you don't want to run the binary every time you want to SSH over USB.
+The above command maps port `22` on the iOS device to port `2222` on localhost. You can also [make iproxy run automatically in the background](https://iphonedevwiki.net/index.php/SSH_Over_USB "Making iproxy run automatically in the background on OS X") if you don't want to run the binary every time you want to SSH over USB.
 
 With the following command in a new terminal window, you can connect to the device:
 

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -521,15 +521,15 @@ $ iproxy 2222 22
 waiting for connection
 ```
 
-The above command maps port `22` on the iOS device to port `2222` on localhost. With the following command in a new terminal window, you can connect to the device:
+The above command maps port `22` on the iOS device to port `2222` on localhost. You can also [make the iproxy run automatically in the background](https://iphonedevwiki.net/index.php/SSH_Over_USB "Making iproxy run automatically in the background on OS X") if you don't want to run the binary every time you want to SSH over USB.
+
+With the following command in a new terminal window, you can connect to the device:
 
 ```shell
 $ ssh -p 2222 root@localhost
 root@localhost's password:
 iPhone:~ root#
 ```
-
-You can [make the iproxy run automatically in the background](https://iphonedevwiki.net/index.php/SSH_Over_USB "Making iproxy run automatically in the background on OS X") if you don't want to run the binary every time you want to SSH over USB.
 
 You can also connect to your iPhone's USB via [Needle](https://labs.mwrinfosecurity.com/blog/needle-how-to/ "Needle").
 


### PR DESCRIPTION
Added a link to "Remote Shell" section that shows a step by step guide for making iproxy run automatically in the background to make ssh over usb more convenient. 