### PR TITLE
Update 0x06j-Testing-Resiliency-Against-Reverse-Engineering.md

### DIFF
--- a/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
+++ b/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md
@@ -75,10 +75,6 @@ You can check protocol handlers by attempting to open a Cydia URL. The Cydia app
 if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"cydia://package/com.example.package"]]){
 ```
 
-##### Calling System APIs
-
-Calling the `system` function with a "NULL" argument on a non-jailbroken device will return "0"; doing the same thing on a jailbroken device will return "1". This difference is due to the function's checking for access to `/bin/sh` on jailbroken devices only.
-
 #### Bypassing Jailbreak Detection
 
 Once you start an application that has jailbreak detection enabled on a jailbroken device, you'll notice one of the following things:


### PR DESCRIPTION
Removed reference to calling `system` function for Anti-Reversing Defenses due to `system` no longer being able to be called since iOS 11 (Link found in related issue: https://developer.apple.com/forums/thread/100617)

Optionally, if you would not like to remove this check, you could optionally add a note, but at this point I think most readers of the MSTG are not working applications with a minimum iOS version of 11 

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #1754.
