### PR TITLE
Update 0x06g-Testing-Network-Communication.md

### DIFF
--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -314,7 +314,7 @@ You can look into the [pinning.ts](https://github.com/sensepost/objection/blob/m
 
 See also [Objection's documentation on Disabling SSL Pinning for iOS](https://github.com/sensepost/objection#ssl-pinning-bypass-running-for-an-ios-application "Disable SSL Pinning in iOS" ) for further information.
 
-However, technologies and systems change over time, and this bypass technique might not work eventually. Hence, it is part of the tester work to do some research, as not every tool keeps up OS versions quickly enough.
+However, technologies and systems change over time, and this bypass technique might not work eventually. Hence, it's part of the tester work to do some research, since not every tool is able to keep up with OS versions quickly enough.
 
 For instance, at the time of this writing objection bypass is not working for iOS 10 and above. However, looking in repositories like Frida CodeShare it's possible to find scripts to bypass specific versions, such as ["ios10-ssl-bypass"](https://codeshare.frida.re/@dki/ios10-ssl-bypass/) by @dki which actually works for iOS 10 and 11.
 

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -314,16 +314,11 @@ You can look into the [pinning.ts](https://github.com/sensepost/objection/blob/m
 
 See also [Objection's documentation on Disabling SSL Pinning for iOS](https://github.com/sensepost/objection#ssl-pinning-bypass-running-for-an-ios-application "Disable SSL Pinning in iOS" ) for further information.
 
-In new iOS versions objection bypass might not work because some new techniques have not been implemented yet, like when objection says: `Called nw_tls_create_peer_trust(), no working bypass implemented yet.`.
+However, technologies and systems change over time, and this bypass technique might not work eventually. Hence, it is part of the tester work to do some research, as not every tool keeps up OS versions quickly enough.
 
-However it is possible to make it work with Frida, in this case:
+For instance, at the time of this writing objection bypass is not working for iOS 10 and above. However, looking in repositories like Frida CodeShare it is possible to find scripts to bypass specific versions, like [this one for iOS 10 and 11](https://codeshare.frida.re/@dki/ios10-ssl-bypass/).
 
-```bash
-$ frida --codeshare dki/ios10-ssl-bypass -f YOUR_BINARY
-$ [Apple iPhone::AppName]->bypassSSL();
-```
-
-This Frida script hooks into the `nw_tls_create_peer_trust` and `tls_helper_create_peer_trust` and should work for iOS 10 and 11. See also the full code in the [Frida CodeShare repository](https://codeshare.frida.re/@dki/ios10-ssl-bypass/)
+Some apps might implement custom SSL pinning methods, so the tester could also develope new bypass scripts making use of [Frida](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06b-Basic-Security-Testing.md#frida) and the techniques explained in the [reverse engineering](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06c-Reverse-Engineering-and-Tampering.md#ios-tampering-and-reverse-engineering) section.
 
 If you want to get more details about white box testing and typical code patterns, refer to [#thiel]. It contains descriptions and code snippets illustrating the most common certificate pinning techniques.
 

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -314,6 +314,17 @@ You can look into the [pinning.ts](https://github.com/sensepost/objection/blob/m
 
 See also [Objection's documentation on Disabling SSL Pinning for iOS](https://github.com/sensepost/objection#ssl-pinning-bypass-running-for-an-ios-application "Disable SSL Pinning in iOS" ) for further information.
 
+In new iOS versions objection bypass might not work because some new techniques have not been implemented yet, like when objection says: `Called nw_tls_create_peer_trust(), no working bypass implemented yet.`.
+
+However it is possible to make it work with Frida, in this case:
+
+```bash
+$ frida --codeshare dki/ios10-ssl-bypass -f YOUR_BINARY
+$ [Apple iPhone::AppName]->bypassSSL();
+```
+
+This Frida script hooks into the `nw_tls_create_peer_trust` and `tls_helper_create_peer_trust` and should work for iOS 10 and 11. See also the full code in the [Frida CodeShare repository](https://codeshare.frida.re/@dki/ios10-ssl-bypass/)
+
 If you want to get more details about white box testing and typical code patterns, refer to [#thiel]. It contains descriptions and code snippets illustrating the most common certificate pinning techniques.
 
 ### References

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -316,7 +316,7 @@ See also [Objection's documentation on Disabling SSL Pinning for iOS](https://gi
 
 However, technologies and systems change over time, and this bypass technique might not work eventually. Hence, it is part of the tester work to do some research, as not every tool keeps up OS versions quickly enough.
 
-For instance, at the time of this writing objection bypass is not working for iOS 10 and above. However, looking in repositories like Frida CodeShare it is possible to find scripts to bypass specific versions, like [this one for iOS 10 and 11](https://codeshare.frida.re/@dki/ios10-ssl-bypass/).
+For instance, at the time of this writing objection bypass is not working for iOS 10 and above. However, looking in repositories like Frida CodeShare it's possible to find scripts to bypass specific versions, such as ["ios10-ssl-bypass"](https://codeshare.frida.re/@dki/ios10-ssl-bypass/) by @dki which actually works for iOS 10 and 11.
 
 Some apps might implement custom SSL pinning methods, so the tester could also develop new bypass scripts making use of [Frida](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06b-Basic-Security-Testing.md#frida) and the techniques explained in the ["iOS Reverse Engineering"](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06c-Reverse-Engineering-and-Tampering.md) chapter.
 

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -318,7 +318,7 @@ However, technologies and systems change over time, and this bypass technique mi
 
 For instance, at the time of this writing objection bypass is not working for iOS 10 and above. However, looking in repositories like Frida CodeShare it is possible to find scripts to bypass specific versions, like [this one for iOS 10 and 11](https://codeshare.frida.re/@dki/ios10-ssl-bypass/).
 
-Some apps might implement custom SSL pinning methods, so the tester could also develope new bypass scripts making use of [Frida](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06b-Basic-Security-Testing.md#frida) and the techniques explained in the [reverse engineering](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06c-Reverse-Engineering-and-Tampering.md#ios-tampering-and-reverse-engineering) section.
+Some apps might implement custom SSL pinning methods, so the tester could also develop new bypass scripts making use of [Frida](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06b-Basic-Security-Testing.md#frida) and the techniques explained in the ["iOS Reverse Engineering"](https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06c-Reverse-Engineering-and-Tampering.md) chapter.
 
 If you want to get more details about white box testing and typical code patterns, refer to [#thiel]. It contains descriptions and code snippets illustrating the most common certificate pinning techniques.
 


### PR DESCRIPTION
SSL Pining bypass for iOS 10 and 11 (objection error Called nw_tls_create_peer_trust(), no working bypass implemented yet.)

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #< insert number here >.
