### PR TITLE
Including Xamarin, React Native & Flutter in Native apps

### DIFF
--- a/Document/0x04a-Mobile-App-Taxonomy.md
+++ b/Document/0x04a-Mobile-App-Taxonomy.md
@@ -14,7 +14,13 @@ Native apps inherently have the capability to provide the fastest performance wi
 
 Some ambiguity exists when discussing *native apps* for Android as the platform provides two development kits - the Android SDK and the Android NDK. The SDK, which is based on the Java and Kotlin programming language, is the default for developing apps. The NDK (or Native Development Kit) is a C/C++ development kit used for developing binary libraries that can directly access lower level APIs (such as OpenGL). These libraries can be included in regular apps built with the SDK. Therefore, we say that Android *native apps* (i.e. built with the SDK) may have *native* code built with the NDK.
 
-The most obvious downside of *native apps* is that they target only one specific platform. To build the same app for both Android and iOS, one needs to maintain two independent code bases, or introduce often complex development tools to port a single code base to two platforms (e.g. [Xamarin](https://www.xamarin.com/ "Xamarin")).
+The most obvious downside of *native apps* is that they target only one specific platform. To build the same app for both Android and iOS, one needs to maintain two independent code bases, or introduce often complex development tools to port a single code base to two platforms. Currently there are following frameworks which offer such functionality:
+
+- [Xamarin](https://www.xamarin.com/ "Xamarin")
+- [Flutter](https://flutter.dev/ "Flutter")
+- [React Native](https://reactnative.dev/ "React Native")
+
+Applications developed using these frameworks internally uses the APIs native to the system and offer performance equivalent to native applications. These apps can make use of all device capabilities, including the GPS, accelerometer, camera, the notification system, etc. Since the final output is very similar to previously discussed *native apps*, apps developed using these frameworks can also be considered *native*.
 
 ## Web App
 
@@ -37,7 +43,6 @@ Following is a non-exhaustive list of more popular frameworks for developing *hy
 - [Google Flutter](https://flutter.dev/ "Google Flutter")
 - [Native Script](https://www.nativescript.org/ "Native Script")
 - [Onsen UI](https://onsen.io/ "Onsen UI")
-- [React Native](https://www.reactnative.com/ "React Native")
 - [Sencha Touch](https://www.sencha.com/products/touch/ "Sencha Touch")
 
 ## Progressive Web App

--- a/Document/0x04a-Mobile-App-Taxonomy.md
+++ b/Document/0x04a-Mobile-App-Taxonomy.md
@@ -20,7 +20,7 @@ The most obvious downside of *native apps* is that they target only one specific
 - [Flutter](https://flutter.dev/ "Flutter")
 - [React Native](https://reactnative.dev/ "React Native")
 
-Applications developed using these frameworks internally uses the APIs native to the system and offer performance equivalent to native applications. These apps can make use of all device capabilities, including the GPS, accelerometer, camera, the notification system, etc. Since the final output is very similar to previously discussed *native apps*, apps developed using these frameworks can also be considered *native*.
+Applications developed using these frameworks internally use the APIs native to the system and offer performance equivalent to native applications. Also, these apps can make use of all device capabilities, including the GPS, accelerometer, camera, the notification system, etc. Since the final output is very similar to previously discussed *native apps*, apps developed using these frameworks can also be considered as *native apps*.
 
 ## Web App
 


### PR DESCRIPTION
For #1787 

I propose to include Xamarin, Flutter and React Native apps as Native apps. Some reasons being: 

- All these frameworks claim to develop "native apps", using Native APIs and with native performance.  [Xamarin](https://dotnet.microsoft.com/apps/xamarin) website is full of word "native". 
- The output is unlike web apps (the other broader category to compare too) and more like a native app. 
- EU study  on  "[Security Privacy and data protection in mobile applications](https://www.enisa.europa.eu/publications/privacy-and-data-protection-in-mobile-applications/at_download/fullReport)" Pg. 32 categorizes the applications into 3 as well.  Thus we can stick with categories used by other major organizations. 
- Adding another category (lets say "nearly native" or "almost native") doesn't add any considerable value and will only lead to complicating and re-adapting some of our existing content. 

Instead if needed  we may add a note - In the book when we use "native" it mostly refer to apps developed using official languages, as we dont discuss about other frameworks anyways. 

Let me know if this sounds good? 