### PR TITLE
New way to implement cert pinning for iOS

### DIFF
--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -222,7 +222,9 @@ Verify that the server certificate is pinned. Pinning can be implemented on vari
 2. Limiting certificate issuer to e.g. one entity and bundling the intermediate CA's public key into the application. In this way we limit the attack surface and have a valid certificate.
 3. Owning and managing your own PKI. The application would contain the intermediate CA's public key. This avoids updating the application every time you change the certificate on the server, due to e.g. expiration. Note that using your own CA would cause the certificate to be self-singed.
 
-The code presented below shows how it is possible to check if the certificate provided by the server matches the certificate stored in the app. The method below implements the connection authentication and tells the delegate that the connection will send a request for an authentication challenge.
+The latest approach recommended by Apple is to specify a pinned CA public key in the `Info.plist` file under App Transport Security Settings. You can find an example in their article [Identity Pinning: How to configure server certificates for your app](https://developer.apple.com/news/?id=g9ejcf8y "Identity Pinning: How to configure server certificates for your app").
+
+Another common approach is to check if the certificate provided by the server matches the certificate stored in the app. The method below implements the connection authentication and tells the delegate that the connection will send a request for an authentication challenge.
 
 The delegate must implement `connection:canAuthenticateAgainstProtectionSpace:` and `connection: forAuthenticationChallenge`. Within `connection: forAuthenticationChallenge`, the delegate must call `SecTrustEvaluate` to perform customary X.509 checks. The snippet below implements a check of the certificate.
 

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -229,6 +229,7 @@ Another common approach is to use the [`connection:willSendRequestForAuthenticat
 Note that if you compare local and remote certificates, you will have to update the app when the remote certificate changes. A fallback certificate can be stored in the app to make the transition more smooth. Alternatively, the pin can be based on public-key comparison. Thus if the remote certificate changes, the public key stays the same.
 
 The following third-party libraries include pinning functionality:
+
 - [TrustKit](https://github.com/datatheorem/TrustKit "TrustKit"): here you can pin by setting the public key hashes in your Info.plist or provide the hashes in a dictionary. See their readme for more details.
 - [AlamoFire](https://github.com/Alamofire/Alamofire "AlamoFire"): here you can define a `ServerTrustPolicy` per domain for which you can define the pinning method.
 - [AFNetworking](https://github.com/AFNetworking/AFNetworking "AfNetworking"): here you can set an `AFSecurityPolicy` to configure your pinning.

--- a/Document/0x06g-Testing-Network-Communication.md
+++ b/Document/0x06g-Testing-Network-Communication.md
@@ -226,7 +226,7 @@ The latest approach recommended by Apple is to specify a pinned CA public key in
 
 Another common approach is to use the [`connection:willSendRequestForAuthenticationChallenge:`](https://developer.apple.com/documentation/foundation/nsurlconnectiondelegate/1414078-connection?language=objc "connection:willSendRequestForAuthenticationChallenge:") method of `NSURLConnectionDelegate` to check if the certificate provided by the server is valid and matches the certificate stored in the app. You can find more details in the [HTTPS Server Trust Evaluation](https://developer.apple.com/library/archive/technotes/tn2232/_index.html#//apple_ref/doc/uid/DTS40012884-CH1-SECNSURLCONNECTION "HTTPS Server Trust Evaluation") technical note.
 
-Note that if you compare local and remote certificates, you will have to update the app when the remote certificate changes. A fallback certificate can be stored in the app to make the transition more smooth. Alternatively, the pin can be based on public-key comparison. Thus if the remote certificate changes, the public key stays the same.
+Note that if you compare local and remote certificates, you will have to update the app when the remote certificate changes. A fallback certificate can be stored in the app to make the transition smoother. Alternatively, the pin can be based on public-key comparison. Thus if the remote certificate changes, the public key stays the same.
 
 The following third-party libraries include pinning functionality:
 


### PR DESCRIPTION
Added details about a new approach to implementing certificate pinning on iOS. As per Apple article https://developer.apple.com/news/?id=g9ejcf8y it is now possible to specify CA public key in Info.plist file, and this should be enough for pinning to work.

Also, replaced the code example with a reference to the official documentation and simplified the description.
___
- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
___
This contribution was discussed with @sushi2k and @vixentael
