### PR TITLE
Added instructions explaining how to move certificate from user to root store

### DIFF
--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -756,6 +756,12 @@ An easy way to install a CA certificate is to push the certificate to the device
 
 You should then be prompted to confirm installation of the certificate (you'll also be asked to set a device PIN if you haven't already).
 
+This installs the certificate in the user certificate store. In order to place the certificate in the root store you can perform the following steps:
+1. Run adb as root with `adb root` and `adb shell`.
+2. Locate the newly installed certificate at `/data/misc/user/0/cacerts-added/`.
+3. Copy the certificate to the following folder `/system/etc/security/cacerts/`.
+4. Reboot the Android VM.
+
 For Android 7.0 (API level 24) and above follow the same procedure described in the "[Bypassing the Network Security Configuration](#bypassing-the-network-security-configuration "Bypassing the Network Security Configuration")" section.
 
 #### Interception Proxy for a Physical Device

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -756,7 +756,7 @@ An easy way to install a CA certificate is to push the certificate to the device
 
 You should then be prompted to confirm installation of the certificate (you'll also be asked to set a device PIN if you haven't already).
 
-This installs the certificate in the user certificate store. In order to place the certificate in the root store you can perform the following steps:
+This installs the certificate in the user certificate store (Tested on Genymotion VM). In order to place the certificate in the root store you can perform the following steps:
 1. Run adb as root with `adb root` and `adb shell`.
 2. Locate the newly installed certificate at `/data/misc/user/0/cacerts-added/`.
 3. Copy the certificate to the following folder `/system/etc/security/cacerts/`.

--- a/Document/0x05b-Basic-Security_Testing.md
+++ b/Document/0x05b-Basic-Security_Testing.md
@@ -757,6 +757,7 @@ An easy way to install a CA certificate is to push the certificate to the device
 You should then be prompted to confirm installation of the certificate (you'll also be asked to set a device PIN if you haven't already).
 
 This installs the certificate in the user certificate store (Tested on Genymotion VM). In order to place the certificate in the root store you can perform the following steps:
+
 1. Run adb as root with `adb root` and `adb shell`.
 2. Locate the newly installed certificate at `/data/misc/user/0/cacerts-added/`.
 3. Copy the certificate to the following folder `/system/etc/security/cacerts/`.


### PR DESCRIPTION
Added instructions explaining how to move the burp certificate from user to root store.

You can also add alternative certificate installation instructions. The current instructions download the cert outside android VM, push it and install it. This can all be done from within the Android VM as well.

The instructions would be as followed:

1. Start Burp and configure your Android VM Wi-Fi settings to use Burp proxy.
2. Visit http://burp, and download the certificate.
3. Rename the certificate to cacert.cer.
4. Open the file and you will be prompted to confirm installation of the certificate.

Let me know what you think about the alternative instructions as well and if it would fit in the document or not.