### PR TITLE
Patching iOS app for Debugging

### DIFF
--- a/Document/0x06c-Reverse-Engineering-and-Tampering.md
+++ b/Document/0x06c-Reverse-Engineering-and-Tampering.md
@@ -756,6 +756,12 @@ Successfully inserted a LC_LOAD_DYLIB command for arm64
 Writing executable to Payload/UnCrackable Level 1.app/UnCrackable Level 1...
 ```
 
+#### Patching Example: Making an App Debuggable
+
+By default, an app available on Apple App Store is not debuggable. In order to debug an iOS application, it must have `get-task-allow` entitlement enabled. This entitlement allows other processes (like a debugger) to attach to the app. Apple does not allow `get-task-allow` entitlement to be enabled in a distribution provisioning profile; it is only allowed in a development provisioning profile.
+
+Thus, to debug an iOS application obtained from the App Store, it needs to be re-signed with a development provisioning profile with `get-task-allow` entitlement. How to re-sign an application is discussed in the next section.
+
 #### Repackaging and Re-Signing
 
 Of course, tampering an app invalidates the main executable's code signature, so this won't run on a non-jailbroken device. You'll need to replace the provisioning profile and sign both the main executable and the files you've made include (e.g. `FridaGadget.dylib`) with the certificate listed in the profile.


### PR DESCRIPTION
Added content on how to patch an iOS app to make it debuggable.

This PR closes #1375 .