### PR TITLE
Correcting link errors based on failed checks

### DIFF
--- a/Crackmes/README.md
+++ b/Crackmes/README.md
@@ -28,7 +28,7 @@ This app is compatible with Android 4.4 and up.
 - [Solution using static analysis](../Document/0x05c-Reverse-Engineering-and-Tampering.md#reviewing-decompiled-java-code "Solution using static analysis")
 - [Solution using jdb](../Document/0x05c-Reverse-Engineering-and-Tampering.md#debugging-with-jdb "Solution using jdb")
 - [Solution using Frida by Eduardo Novella](https://enovella.github.io/android/reverse/2017/05/18/android-owasp-crackmes-level-1.html "Solution by Eduardo Novella")
-- [Solution using Xposed by sh3llc0d3r](http://sh3llc0d3r.com/owasp-uncrackable-android-level1/ "Solution by sh3llc0d3r")
+- [Solution using Xposed by sh3llc0d3r](https://web.archive.org/web/20210124161121/http://sh3llc0d3r.com/owasp-uncrackable-android-level1/ "Solution by sh3llc0d3r")
 - [Solution using RMS by @mobilesecurity_ (video)](https://youtu.be/P6rNPkM2DdY "Solution by @mobilesecurity_")
 - [Solution using static analysis by Eduardo Vasconcelos](https://tereresecurity.wordpress.com/2021/03/03/write-up-uncrackable-level-1/ "Solution by Eduardo Vasconcelos")
 - [Solution using Frida by Davide Cioccia](https://1337.dcodx.com/mobile-security/owasp-mstg-crackme-1-writeup-android "Solution by Davide Cioccia")
@@ -54,7 +54,7 @@ This app is compatible with Android 4.4 and up.
 
 - [Solution using Frida and radare2 by c0dmtr1x](https://www.codemetrix.net/hacking-android-apps-with-frida-3/ "Solution by c0dmtr1x").
 - [Solution using Frida by Eduardo Novella](https://enovella.github.io/android/reverse/2017/05/20/android-owasp-crackmes-level-2.html "Solution by Eduardo Novella").
-- [Solution using patches by sh3llc0d3r](http://sh3llc0d3r.com/owasp-uncrackable-android-level2/ "Solution by sh3llc0d3r").
+- [Solution using patches by sh3llc0d3r](https://web.archive.org/web/20210124162744/http://sh3llc0d3r.com/owasp-uncrackable-android-level2/ "Solution by sh3llc0d3r").
 - [Solution using RMS by @mobilesecurity_ (video)](https://youtu.be/xRQVljerl0A "Solution by @mobilesecurity_").
 - [Solution using static analysis and Ghidra by Eduardo Vasconcelos](https://tereresecurity.wordpress.com/2021/03/23/write-up-uncrackable-level-2/ "Solution by Eduardo Vasconcelos").
 - [Solution using Ghidra and Frida by Davide Cioccia](https://1337.dcodx.com/mobile-security/owasp-mstg-crackme-2-writeup-android "Solution by Davide Cioccia")
@@ -79,7 +79,7 @@ $ adb install UnCrackable-Level3.apk
 #### Solutions
 
 - [Solution using Frida by Eduardo Novella](https://enovella.github.io/android/reverse/2017/05/20/android-owasp-crackmes-level-3.html "Solution by Eduardo Novella").
-- [Solution using patches by sh3llc0d3r](http://sh3llc0d3r.com/owasp-uncrackable-android-level3/ "Solution by sh3llc0d3r").
+- [Solution using patches by sh3llc0d3r](https://web.archive.org/web/20210124164453/http://sh3llc0d3r.com/owasp-uncrackable-android-level3/ "Solution by sh3llc0d3r").
 - [Solution using Ghidra and Frida by Davide Cioccia](https://1337.dcodx.com/mobile-security/owasp-mstg-crackme-3-writeup-android "Solution by Davide Cioccia")
 
 ### [UnCrackable App for Android Level 4: Radare2 Pay v0.9](Android/Level_04 "Android level 4")

--- a/Document/0x06b-Basic-Security-Testing.md
+++ b/Document/0x06b-Basic-Security-Testing.md
@@ -24,7 +24,7 @@ The UDID is a 40-digit unique sequence of letters and numbers to identify an iOS
 
 ![OWASP MSTG](Images/Chapters/0x06b/UDID-Finder.png) \
 
-If you are using a macOS version before Catalina, you can find the [UDID of your iOS device via iTunes](http://www.iclarified.com/52179/how-to-find-your-iphones-udid "How to Find Your iPhone\'s UDID"), by selecting your device and clicking on "Serial Number" in the summary tab. When clicking on this you will iterate through different metadata of the iOS device including its UDID.
+If you are using a macOS version before Catalina, you can find the [UDID of your iOS device via iTunes](https://www.iclarified.com/52179/how-to-find-your-iphones-udid "How to Find Your iPhone\'s UDID"), by selecting your device and clicking on "Serial Number" in the summary tab. When clicking on this you will iterate through different metadata of the iOS device including its UDID.
 
 It is also possible to get the UDID via various command line tools on macOS while the device is attached via USB:
 

--- a/Users.md
+++ b/Users.md
@@ -23,7 +23,7 @@ Currently the MASVS and MSTG are used by at least the following companies:
 - [Randorisec](https://randorisec.fr/ "Randorisec")
 - [Secarma](https://www.secarma.com/ "Secarma")
 - [SecuRing](https://securing.biz/ "SecuRing")
-- [Stingray Technologies](https://stingray.appsec.global/  "Stingray Technologies")
+- [Stingray Technologies](https://stingray-mobile.ru/  "Stingray Technologies")
 - [STM Solutions](https://stmsolutions.pl/ "STM Solutions")
 - [Toreon](https://www.toreon.com/ "Toreon")
 - [VantagePoint](https://www.vantagepoint.sg "VantagePoint")


### PR DESCRIPTION
The github actions are resulting in multiple link check fails. correcting some of them here.

1. https://support.virustotal.com/hc/en-us/articles/115002146549-Mobile-Apps link is a problematic link as its default response code is 403 which causes scripts to fail. Someone need to relook at the script to see if a exception can be added.