### PR TITLE
Fix typo in 0x06i-Testing-Code-Quality-and-Build-Settings.md

### DIFF
--- a/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
+++ b/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md
@@ -214,7 +214,7 @@ In case [CocoaPods](https://cocoapods.org "CocoaPods.org") is used for managing 
 First, at the root of the project, where the Podfile is located, execute the following commands:
 
 ```bash
-$ sudo gem install CocoaPods
+$ sudo gem install cocoapods
 $ pod install
 ```
 


### PR DESCRIPTION
`sudo gem install CocoaPods` does not work, and anyone doing this will end up with 
```
gem install CocoaPods
ERROR:  Could not find a valid gem 'CocoaPods' (>= 0) in any repository
```

The correct gem should be `cocoapods` found [here](https://rubygems.org/gems/cocoapods)

Thank you for submitting a Pull Request to the Mobile Security Testing Guide. Please make sure that:
