### PR TITLE
[Document Local Build] Remove gsed dependency on macOS

### DIFF
--- a/tools/docker/pandoc_makedocs.sh
+++ b/tools/docker/pandoc_makedocs.sh
@@ -21,11 +21,7 @@ PANDOC_PARAMS+="--metadata version=${VERSION} "
 PANDOCKER="docker run --rm --volume `pwd`:/pandoc ${IMG}:${TAG} ${PANDOC_PARAMS}"
 
 # remove the HTML comment from \pagebreak
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  gsed -i 's#<!-- \(.*\) -->#\1#g' Document/*.md
-else
-  sed -i 's#<!-- \(.*\) -->#\1#g' Document/*.md
-fi
+docker run --rm --entrypoint '/bin/sh' --volume `pwd`:/pandoc ${IMG}:${TAG} -c 'sed -i "s#<!-- \(.*\) -->#\1#g" Document/*.md'
 
 # Use pandocker PANDOCKER by default, unless `export PANDOC=pandoc`
 # this is useful for CI, because we can run the script directly inside the container


### PR DESCRIPTION
Now sed runs in docker, no gsed needed in macos.