### PR TITLE
Add damnvulnerableiosapp.com to exception list for link checker

### DIFF
--- a/.github/workflows/config/mlc_config.json
+++ b/.github/workflows/config/mlc_config.json
@@ -41,6 +41,9 @@
         },
         {
             "pattern": "^https://www.europeanpaymentscouncil.eu"
+        },
+        {
+            "pattern": "^http://damnvulnerableiosapp.com/"
         }
     ],
     "httpHeaders": [


### PR DESCRIPTION
Adding this website to the exception list for the link checker, as this URL sometimes gives a timeout.