### PR TITLE
Remove extra '\' after image in content

### DIFF
--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -16,7 +16,7 @@ Every file stored on the iOS file system is encrypted with its own per-file key,
 
 The following illustration shows the [iOS Data Protection Key Hierarchy](https://www.apple.com/business/docs/iOS_Security_Guide.pdf "iOS Security Guide").
 
-![OWASP MSTG](Images/Chapters/0x06d/key_hierarchy_apple.jpg) \
+![OWASP MSTG](Images/Chapters/0x06d/key_hierarchy_apple.jpg)
 
 Files can be assigned to one of four different protection classes, which are explained in more detail in the [iOS Security Guide](https://www.apple.com/business/docs/iOS_Security_Guide.pdf "iOS Security Guide"):
 


### PR DESCRIPTION
There was a random \ after the image which served no purpose.