### PR TITLE
[Regression Test] pandocker 21.02

### DIFF
--- a/tools/docker/pandoc_makedocs.sh
+++ b/tools/docker/pandoc_makedocs.sh
@@ -8,7 +8,7 @@ VERSION=${2:-SNAPSHOT}
 
 # You can also use the environment variables below to adapt the build process
 IMG=${IMG:-dalibo/pandocker}
-TAG=${TAG:-stable} # /!\ use stable-full for non-european languages
+TAG=${TAG:-21.02} # /!\ use stable-full for non-european languages
 LATEX_TEMPLATE=${LATEX_TEMPLATE:-eisvogel}
 TITLE=${TITLE:-OWASP Mobile Security Testing Guide ${VERSION}}
 


### PR DESCRIPTION
The latest [pandocker 22.03](https://github.com/dalibo/pandocker/releases/tag/22.03) (released 9 days ago) seems to have some issues, since our document generation pipeline fails (since at least 4 days ago) and we didn't introduce any changes.

https://github.com/OWASP/owasp-mstg/runs/5673350862?check_suite_focus=true

```
Status: Downloaded newer image for dalibo/pandocker:stable
Error producing PDF.
! Missing \endcsname inserted.
<to be read again> 
                   \unhbox 
l.538 ....-6a6c200874bcb4cd/Images/OWASP_logo.png}

Error: Process completed with exit code 43.

```


Checking if we need a regression to [pandocker 22.01](https://github.com/dalibo/pandocker/releases/tag/22.01).

**UPDATE:** this PR's build works as expected. See https://github.com/OWASP/owasp-mstg/runs/5691764709?check_suite_focus=true