### PR TITLE
Change news link to archive link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,7 +208,7 @@ nav:
       - crackmes/index.md
       - ... | flat | crackmes/*.md
   - News:
-      - news/index.md
+      - news/archive/2024
   - talks.md
   - "&#11088; Contribute":
       - contributing.md


### PR DESCRIPTION
This makes the NEWS button in the main navigation link to /news/archive/2024 while we continue troubleshooting why the main /news/ page doesn't work.