### PR TITLE
Add URL pattern exception and update documentation references

### DIFF
--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -106,6 +106,9 @@
             "pattern": "^https://github.com/sushi2k/MSTG-MASVS-Internal"
         },
         {
+            "pattern": "^https://fidoalliance.org/"
+        },
+        {
             "pattern": "^/MASVS/"
         },
         {

--- a/weaknesses/MASVS-AUTH/MASWE-0036.md
+++ b/weaknesses/MASVS-AUTH/MASWE-0036.md
@@ -12,7 +12,7 @@ refs:
 - https://developers.google.com/identity/blockstore/android?hl=en
 - https://cloud.google.com/docs/authentication/best-practices-applications#semi-trusted_or_restricted_environments
 - https://cloud.google.com/docs/authentication/best-practices-applications#security_considerations
-- https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple/
+- https://developer.apple.com/documentation/signinwithapplerestapi
 draft:
   description: General authentication material management best practices. Note that API keys are covered separately.
   topics:

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0100.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0100.md
@@ -14,9 +14,9 @@ refs:
 - https://www.youtube.com/watch?v=TyxL78e5Bag
 - https://github.com/1nikolas/play-integrity-checker-app
 - https://developer.apple.com/videos/play/wwdc2021/10244/ 
-- https://developer.apple.com/documentation/devicecheck/preparing_to_use_the_app_attest_service 
+- https://developer.apple.com/documentation/devicecheck/preparing-to-use-the-app-attest-service 
 - https://github.com/iansampson/AppAttest 
-- https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h 
+- https://github.com/firebase/firebase-ios-sdk/blob/v8.15.0/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService%2BFIRAppAttestService.h 
 - https://blog.restlesslabs.com/john/ios-app-attest
 draft:
   description: e.g. Gooogle Play Integrity API, iOS DeviceCheck API


### PR DESCRIPTION
Add a URL pattern exception for the FIDO Alliance and update references in the documentation for MASWE-0036 and MASWE-0100 to ensure accuracy and consistency.