### PR TITLE
Move Last Updated to bottom right

### DIFF
--- a/docs/hooks/add-tags.py
+++ b/docs/hooks/add-tags.py
@@ -26,7 +26,6 @@ def _on_page_markdown_2(markdown, page, **kwargs):
 
     # If any of these tags don't exist, they will be stripped automatically at the end of the function
     tags.append(page.meta.get("masvs_category"))
-
     if page.meta.get("test"):
         tags.append("placeholder-tag-test")
     tags.append(page.meta.get("component_type", "").lower())

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,9 +8,7 @@
     {% endif %}
 
     {% if page.meta.last_updated %}
-    <em><small style="color: darkgrey;">Last updated: {{ page.meta.last_updated }}</small></em>
-    <br><br>
+    <em class="last-updated-on"><small style="color: darkgrey;">Last updated: {{ page.meta.last_updated }}</small></em>
     {% endif %}
     {{ super() }}
-   
 {% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -96,6 +96,19 @@
   padding: 0.3em;
 }
 
+.md-main {
+  position: relative;
+}
+
+.last-updated-on {
+  position: absolute;
+  bottom: -2em;
+  right: 0;
+}
+.md-content__inner{
+  position: relative;
+  margin-bottom: 2rem;
+}
 
 /* Wider space for pages */
 .md-grid {


### PR DESCRIPTION
To make more room for the important content of each page, the last-edited is moved to the bottom right.