### PR TITLE
Fix missing comma in LAPolicy object

### DIFF
--- a/demos/ios/MASVS-AUTH/MASTG-DEMO-0042/script.js
+++ b/demos/ios/MASVS-AUTH/MASTG-DEMO-0042/script.js
@@ -3,7 +3,7 @@ Interceptor.attach(ObjC.classes.LAContext["- evaluatePolicy:localizedReason:repl
 
       const LAPolicy = {
           1: ".deviceOwnerAuthenticationWithBiometrics",
-          2: ".deviceOwnerAuthentication"
+          2: ".deviceOwnerAuthentication",
           3: ".deviceOwnerAuthenticationWithWatch",
           4: ".deviceOwnerAuthenticationWithBiometricsOrWatch",
           5: ".deviceOwnerAuthenticationWithWristDetection",


### PR DESCRIPTION
This PR addresses a syntax error by adding a missing comma in the LAPolicy object definition. This change ensures proper parsing of the object.

