### PR TITLE
Fix package name assignment in backup script

### DIFF
--- a/utils/mastg-android-backup-adb.sh
+++ b/utils/mastg-android-backup-adb.sh
@@ -6,10 +6,10 @@ if [ -z "$1" ]; then
     exit 1
 
 else
-    package_name="$1"
+    package_name="$0"
 fi
 
-adb backup -apk -nosystem $package_name
+adb backup -apk -nosystem $package_name $1
 tail -c +25 backup.ab | python3 -c "import zlib,sys;sys.stdout.buffer.write(zlib.decompress(sys.stdin.buffer.read()))" > backup.tar
 tar xvf backup.tar
 


### PR DESCRIPTION
Corrected the assignment of the package name variable to use the first argument instead of the script name.

This PR closes #issue_number

## Description

Provide a brief description of the changes introduced by this PR.

-------------------

[x] I have read the contributing guidelines.

## Guidelines for Pull Requests (you can delete this section after reading):

- Please ensure that your content follows the [style guide](https://mas.owasp.org/contributing/).
- If you are working on Porting MASTG v1 Tests to v2, refer to [this document](https://docs.google.com/document/d/1veyzE4cVTSnIsKB1DOPUSMhjXow_MtJOtgHeo5HVoho/edit?usp=sharing).
- If you are working on new MASWE, tests, or demos, refer to [this document](https://docs.google.com/document/d/1EMsVdfrDBAu0gmjWAUEs60q-fWaOmDB5oecY9d9pOlg/edit?usp=sharing).

