### PR TITLE
MASTG-APP-0031: Add VulnForum - Intentionally Vulnerable Android App …

### DIFF
--- a/apps/android/MASTG-APP-0031.md
+++ b/apps/android/MASTG-APP-0031.md
@@ -9,9 +9,10 @@ VulnForum is an intentionally vulnerable mobile forum application designed for s
 The application uses a modern technology stack, featuring a native Android frontend built with **Kotlin and Jetpack Compose** and an API backend implemented with **Python Flask**.
 
 It covers a broad spectrum of common mobile and API security flaws, including:
-* **Injection:** SQL Injection and Cross-Site Scripting (XSS).
-* **Access Control:** Broken authorization logic and improper token validation.
-* **Data Security:** Insecure data storage, verbose logging, and hardcoded secrets.
-* **Platform:** Exploitable exported components and misconfigured deep links.
+
+- **Injection:** SQL Injection and Cross-Site Scripting (XSS).
+- **Access Control:** Broken authorization logic and improper token validation.
+- **Data Security:** Insecure data storage, verbose logging, and hardcoded secrets.
+- **Platform:** Exploitable exported components and misconfigured deep links.
 
 The repository provides detailed setup instructions and a specific set of **Flags/Challenges** for users to validate their exploitation skills.


### PR DESCRIPTION
…(Kotlin/Flask)

## Description

Adding VulnForum, a deliberately vulnerable Android application (Kotlin/Jetpack Compose) with a Flask backend, as suggested by Sven Schleier to serve as a new training app for MASTG.

VulnForum uses a modern stack (Kotlin/Jetpack Compose) and covers a broad range of common mobile and API security flaws.

Link to the vulnerable app repo: https://github.com/macik09/Vulnforum

-------------------

[x] I have read the contributing guidelines.

