### PR TITLE
Reserve IDs

### DIFF
--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0068/MASTG-DEMO-0068.md
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0068/MASTG-DEMO-0068.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Reserved for MASWE-0006 - Unencrypted SQLite Storage (Alternative Demo)
+id: MASTG-DEMO-0068
+code: [kotlin]
+test: MASTG-TEST-0304
+status: placeholder
+note: This placeholder reserves the ID for a potential alternative or expanded demo related to unencrypted SQLite storage, linked to the MASTG-TEST-0304 test case.
+---

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0069/MASTG-DEMO-0069.md
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0069/MASTG-DEMO-0069.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Sensitive Data Stored Unencrypted via DataStore
+id: MASTG-DEMO-0069
+code: [kotlin]
+test: MASTG-TEST-0305
+status: placeholder
+note: This placeholder reserves the ID for a demo illustrating the insecure storage of sensitive data using the modern Jetpack DataStore API without implementing secure encryption mechanisms. It directly corresponds to the MASTG-TEST-0305.
+---

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0070/MASTG-DEMO-0070.md
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0070/MASTG-DEMO-0070.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Sensitive Data Stored Unencrypted via Room Database
+id: MASTG-DEMO-0070
+code: [kotlin]
+test: MASTG-TEST-0306
+status: placeholder
+note: This placeholder reserves the ID for a demo illustrating the insecure storage of sensitive data using the Android Room Persistence Library without integrating an external encryption solution (like SQLCipher). It directly corresponds to the MASTG-TEST-0306.
+---

--- a/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0304.md
+++ b/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0304.md
@@ -1,0 +1,11 @@
+---
+title: Sensitive Data Stored Unencrypted via SQLite 
+platform: android
+id: MASTG-TEST-0304
+type: [static, dynamic]
+weakness: MASWE-0006
+best-practices: []
+profiles: [L1, L2]
+status: placeholder
+note: This test checks if the app uses the default SQLite API (e.g., `SQLiteOpenHelper`, `context.openOrCreateDatabase`) to store sensitive data (e.g., tokens, PII) in an unencrypted database file within the app's sandbox. It confirms the absence of secure alternatives like SQLCipher or encrypted databases.
+---

--- a/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0305.md
+++ b/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0305.md
@@ -1,0 +1,11 @@
+---
+title: Sensitive Data Stored Unencrypted via DataStore 
+platform: android
+id: MASTG-TEST-0305
+type: [static, dynamic]
+weakness: MASWE-0006
+best-practices: []
+profiles: [L1, L2]
+status: placeholder
+note: This test checks if the app uses the modern Jetpack DataStore API (Preferences DataStore or Proto DataStore) to store sensitive data (e.g., tokens, PII) without encryption. It confirms the absence of secure serializers or mechanisms to protect data integrity and confidentiality.
+---

--- a/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0306.md
+++ b/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0306.md
@@ -1,0 +1,11 @@
+---
+title: Sensitive Data Stored Unencrypted via Android Room DB 
+platform: android
+id: MASTG-TEST-0306
+type: [static, dynamic]
+weakness: MASWE-0006
+best-practices: []
+profiles: [L1, L2]
+status: placeholder
+note: This test checks if the app uses the Android Room Persistence Library to store sensitive data (e.g., tokens, PII) without integrating an encryption layer (e.g., SQLCipher). It confirms the database file is stored in plaintext within the app's private sandbox.
+---

--- a/tests/android/MASVS-STORAGE/MASTG-TEST-0001.md
+++ b/tests/android/MASVS-STORAGE/MASTG-TEST-0001.md
@@ -11,7 +11,7 @@ masvs_v1_levels:
 - L2
 profiles: [L1, L2]
 status: deprecated
-covered_by: [MASTG-TEST-0207, MASTG-TEST-0200, MASTG-TEST-0201, MASTG-TEST-0202]
+covered_by: [MASTG-TEST-0207, MASTG-TEST-0200, MASTG-TEST-0201, MASTG-TEST-0202, MASTG-TEST-0304, MASTG-TEST-0305, MASTG-TEST-0306]
 deprecation_note: New version available in MASTG V2
 ---
 


### PR DESCRIPTION
Reserve MASTG-TEST-0304, 0305, 0306 IDs and MASTG-DEMO-0066, 0067 IDs for MASWE-0006

## Description

This Pull Request's primary purpose is **ID reservation** for the complete implementation of the Storage Demos and Tests related to **MASWE-0006 (Unencrypted Storage)**.

The implementation is structured to cover three distinct Android storage technologies (SQLite, DataStore, and Room DB) under the same weakness ID.

### Changes Included:

1.  **Test ID Reservation:** Placeholder files created for **MASTG-TEST-0304**, **0305**, and **0306** in the `tests-beta` folder.
2.  **Demo ID Reservation:** Placeholder files created for **MASTG-DEMO-0066** and **0067**.
3.  **Deprecation Update:** The `covered_by` field in the old test file **MASTG-TEST-0001.md** was updated to reference the new reserved IDs.

These IDs will be used in subsequent PRs that will introduce the actual demo code and test documentation.

-------------------

