### PR TITLE
Fix plugin and section replacement messages in workflow

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -190,15 +190,18 @@ jobs:
             sed -i "s|// ADD_PLUGINS_HERE|$plugins_content|g" mas-app-android/app/build.gradle.kts
             echo "Replaced plugins in build.gradle.kts for $demo"
           else
-            echo "No build.gradle.kts.libs found for $demo, skipping plugins replacement"
+            echo "No build.gradle.kts.plugins found for $demo, skipping plugins replacement"
           fi
 
           if [ -f "$demo/build.gradle.kts.sections" ]; then
-            sections_content=$(cat "$demo/build.gradle.kts.sections")
-            sed -i "s|// ADD_SECTIONS_HERE|$sections_content|g" mas-app-android/app/build.gradle.kts
+            sed -i '/\/\/ ADD_SECTIONS_HERE/{
+              r '"$demo"'/build.gradle.kts.sections
+              d
+            }' mas-app-android/app/build.gradle.kts
+          
             echo "Replaced sections in build.gradle.kts for $demo"
           else
-            echo "No build.gradle.kts.libs found for $demo, skipping sections replacement"
+            echo "No build.gradle.kts.sections found for $demo, skipping sections replacement"
           fi
 
           if [ -f "$demo/build.gradle.kts.libs" ]; then


### PR DESCRIPTION
This pull request makes improvements to the build script logic in `.github/workflows/build-android-demos.yml` for Android demo builds. The main focus is on more robust and accurate handling of plugin and section replacements in the `build.gradle.kts` file.

Build script improvements:

* Corrected the log message to reference `build.gradle.kts.plugins` instead of `build.gradle.kts.libs` when skipping plugin replacement, ensuring clarity in build output.
* Enhanced the section replacement logic by using a `sed` command that inserts the contents of `build.gradle.kts.sections` directly at the marker and deletes the marker line, making the operation more reliable and atomic.
* Updated the log message to reference `build.gradle.kts.sections` instead of `build.gradle.kts.libs` when skipping section replacement, improving accuracy in build logs.