### PR TITLE
Refactor plugin and libs replacement in build script

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -186,8 +186,11 @@ jobs:
           fi
 
           if [ -f "$demo/build.gradle.kts.plugins" ]; then
-            plugins_content=$(cat "$demo/build.gradle.kts.plugins")
-            sed -i "s|// ADD_PLUGINS_HERE|$plugins_content|g" mas-app-android/app/build.gradle.kts
+            sed -i '/\/\/ ADD_PLUGINS_HERE/{
+              r '"$demo"'/build.gradle.kts.plugins
+              d
+            }' mas-app-android/app/build.gradle.kts
+          
             echo "Replaced plugins in build.gradle.kts for $demo"
           else
             echo "No build.gradle.kts.plugins found for $demo, skipping plugins replacement"
@@ -205,13 +208,16 @@ jobs:
           fi
 
           if [ -f "$demo/build.gradle.kts.libs" ]; then
-            libs_content=$(cat "$demo/build.gradle.kts.libs")
-            sed -i "s|// ADD_LIBS_HERE|$libs_content|g" mas-app-android/app/build.gradle.kts
+            sed -i '/\/\/ ADD_LIBS_HERE/{
+              r '"$demo"'/build.gradle.kts.libs
+              d
+            }' mas-app-android/app/build.gradle.kts
+          
             echo "Replaced libs in build.gradle.kts for $demo"
           else
             echo "No build.gradle.kts.libs found for $demo, skipping libs replacement"
           fi
-          
+
           echo "Building APK for $demo"
           cd mas-app-android
           grep -q 'org.gradle.caching=true' gradle.properties || echo -en "\norg.gradle.caching=true\norg.gradle.configuration-cache=true\n" >> gradle.properties


### PR DESCRIPTION
This pull request updates the plugin and library insertion logic in the Android demo build workflow to use a more robust and flexible approach. Instead of simple string replacement, it now inserts the contents of plugin and library files directly at designated markers in `mas-app-android/app/build.gradle.kts`, improving maintainability and correctness.

Improvements to build workflow logic:

* Updated the script to use `sed` to insert the contents of `build.gradle.kts.plugins` at the `// ADD_PLUGINS_HERE` marker and remove the marker line, instead of replacing the marker with the entire file content as a string.
* Updated the script to use `sed` to insert the contents of `build.gradle.kts.libs` at the `// ADD_LIBS_HERE` marker and remove the marker line, instead of replacing the marker with the entire file content as a string.