### PR TITLE
Enhance best practices for preventing keyboard caching in sensitive text inputs

### DIFF
--- a/best-practices/MASTG-BEST-0026.md
+++ b/best-practices/MASTG-BEST-0026.md
@@ -9,8 +9,8 @@ Sensitive text inputs should never participate in keyboard learning or predictio
 
 - For inputs such as usernames, email addresses, recovery codes, and similar data, set `autocorrectionType` to `no` and `spellCheckingType` to `no`. Autocorrection and spell checking rely on analyzing typed content and may retain or resurface that content through suggestions. Disabling both traits ensures the keyboard does not treat these values as language data worth remembering or reusing.
 
-- For password like inputs, always enable `isSecureTextEntry`. Secure text entry masks characters on screen and implicitly disables autocorrection and spell checking. This provides the strongest baseline protection for secrets and avoids accidental exposure through keyboard suggestions, predictive text, or third party keyboards.
+- For password-like inputs, always enable `isSecureTextEntry`. Secure text entry masks characters on screen and implicitly disables autocorrection and spell checking. This provides the strongest baseline protection for secrets and avoids accidental exposure through keyboard suggestions, predictive text, or third-party keyboards.
 
-These traits must be applied consistently across the entire application. Configure them in code or Interface Builder for every security sensitive field, including login, registration, account recovery, payment, and profile related screens.
+These traits must be applied consistently across the entire application. Configure them in code or Interface Builder for every security-sensitive field, including login, registration, account recovery, payment, and profile-related screens.
 
 Any exceptions should be rare and well justified. If spell checking or autocorrection cannot be disabled due to strong usability requirements, the risk should be explicitly assessed and documented.

--- a/knowledge/ios/MASVS-STORAGE/MASTG-KNOW-0100.md
+++ b/knowledge/ios/MASVS-STORAGE/MASTG-KNOW-0100.md
@@ -4,11 +4,11 @@ platform: ios
 title: Keyboard Cache
 ---
 
-Several features such as autocorrection, spell checking, and predictive suggestions help users enter text more quickly. On iOS, these features are backed by on device keyboard dictionaries that are persisted in `.dat` files under `/private/var/mobile/Library/Keyboard/` and its subdirectories. Forensic analyses and security research show that user typed terms, including previously unknown words, can appear in files such as `dynamic-text.dat` in this directory and may be recoverable during device analysis.
+Several features such as autocorrection, spell checking, and predictive suggestions help users enter text more quickly. On iOS, these features are backed by on-device keyboard dictionaries that are persisted in `.dat` files under `/private/var/mobile/Library/Keyboard/` and its subdirectories. Forensic analyses and security research show that user-typed terms, including previously unknown words, can appear in files such as `dynamic-text.dat` in this directory and may be recoverable during device analysis.
 
 The system uses the [`UITextInputTraits`](https://developer.apple.com/documentation/uikit/uitextinputtraits) protocol to control how keyboard assistance and learning behave for a given text control. Standard UIKit controls like [`UITextField`](https://developer.apple.com/documentation/uikit/uitextfield), [`UITextView`](https://developer.apple.com/documentation/uikit/uitextview), and [`UISearchBar`](https://developer.apple.com/documentation/uikit/uisearchbar) conform to this protocol and expose these traits directly.
 
-Key traits that influence what the keyboard learns include
+Key traits that influence what the keyboard learns include:
 
 - [`autocorrectionType`](https://developer.apple.com/documentation/uikit/uitextinputtraits/autocorrectiontype) (default: `UITextAutocorrectionType.default`, enabled): This property controls whether the system attempts to correct what the user types. With autocorrection enabled, the system analyzes entered text, tracks unfamiliar words, and proposes replacements, sometimes substituting them automatically unless the user rejects the suggestion. The default value delegates the decision to the current keyboard and input method, which typically results in autocorrection being enabled.
 - [`spellCheckingType`](https://developer.apple.com/documentation/uikit/uitextinputtraits/spellcheckingtype) (default: `UITextSpellCheckingType.default`, enabled): This property controls spell checking behavior. When enabled, the system underlines suspected misspellings and offers alternatives. Spell checking uses the same underlying language services as autocorrection and contributes to recently observed words that influence suggestions and keyboard learning.


### PR DESCRIPTION
This PR enhances iOS security documentation by expanding guidance on preventing keyboard caching of sensitive text inputs. It updates both the knowledge base article on keyboard caching and the best practices guide to provide comprehensive, security-focused recommendations.

| File | Description |
| ---- | ----------- |
| knowledge/ios/MASVS-STORAGE/MASTG-KNOW-0100.md | Enhanced documentation of iOS keyboard caching behavior with forensic context, detailed explanations of `UITextInputTraits` properties, and their security implications |
| best-practices/MASTG-BEST-0026.md | Added best practices with specific configuration recommendations for preventing keyboard caching in sensitive text inputs |


