### PR TITLE
Add copying of MainActivity.kt in Android App build workflow

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -155,6 +155,9 @@ jobs:
           cp -f "$demo/MastgTest.kt" mas-app-android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt 2>/dev/null \
             && echo "Copied MastgTest.kt for $demo" \
             || echo "No MastgTest.kt found for $demo"
+          cp -f "$demo/MainActivity.kt" mas-app-android/app/src/main/java/org/owasp/mastestapp/MainActivity.kt 2>/dev/null \
+            && echo "Copied MainActivity.kt for $demo" \
+            || echo "No MainActivity.kt found for $demo"
           cp -f "$demo/MastgTestWebView.kt" mas-app-android/app/src/main/java/org/owasp/mastestapp/MastgTestWebView.kt 2>/dev/null \
             && echo "Copied MastgTestWebView.kt for $demo" \
             || echo "No MastgTestWebView.kt found for $demo"


### PR DESCRIPTION


## Description

This pull request makes a small update to the Android demo build workflow. It adds a step to copy the `MainActivity.kt` file from each demo, if present, into the appropriate location in the project during the build process.

* The workflow now attempts to copy `MainActivity.kt` for each demo into `mas-app-android/app/src/main/java/org/owasp/mastestapp/MainActivity.kt`, logging whether the file was found and copied.

-------------------

[x] I have read the contributing guidelines.

## Guidelines for Pull Requests (you can delete this section after reading):

- Please ensure that your content follows the [style guide](https://mas.owasp.org/contributing/).
- If you are working on Porting MASTG v1 Tests to v2, refer to [this document](https://docs.google.com/document/d/1veyzE4cVTSnIsKB1DOPUSMhjXow_MtJOtgHeo5HVoho/edit?usp=sharing).
- If you are working on new MASWE, tests, or demos, refer to [this document](https://docs.google.com/document/d/1EMsVdfrDBAu0gmjWAUEs60q-fWaOmDB5oecY9d9pOlg/edit?usp=sharing).

