### PR TITLE
Update MASTG-KNOW-0101 with additional logging sources

### DIFF
--- a/knowledge/ios/MASVS-STORAGE/MASTG-KNOW-0101.md
+++ b/knowledge/ios/MASVS-STORAGE/MASTG-KNOW-0101.md
@@ -22,12 +22,15 @@ Apart from using secure logging APIs, developers can also implement build config
 
 ## Additional Logging Sources to Consider
 
-While Apple's Unified Logging system is the recommended approach, developers should be aware of other logging sources that may inadvertently expose sensitive information:
 
-- **Native Libraries (C/C++)**: Lower-level native libraries written in C or C++ may write directly to standard output (`stdout`) or standard error (`stderr`) using functions like `printf` or `fprintf`. These outputs may appear in system logs, especially during development and debugging sessions.
 
-- **Crash Reporting and Error Monitoring Tools**: Crash reporting SDKs and error monitoring services may record logs, stack traces, or breadcrumbs to disk and upload them later. These persistent records may outlive a single app session and may include contextual data that could expose sensitive information if not carefully filtered.
 
-- **Networking Stacks and HTTP Clients**: Networking libraries and HTTP clients sometimes provide verbose or debug logging modes that dump headers, URLs, request/response bodies, or payloads. If these modes are enabled outside of debug builds, they may expose credentials or personal data.
+Beyond standard application logging APIs such as `Logger` and `os_log`, iOS applications may inadvertently expose sensitive information through other logging mechanisms:
 
-- **WebView and JavaScript Logs**: Apps that embed web content via `WKWebView` may expose JavaScript console logs and errors. These logs may include sensitive data logged from JavaScript code and may be accessible to native code or reflected in system logs.
+**Legacy Logging APIs**: Deprecated APIs such as `NSLog` and Apple System Log (ASL) write directly to system logs that persist on the device and can be accessed through diagnostic tools or device backups.
+
+**Native Exception and Crash Reporting**: Third-party crash reporting SDKs (e.g., Firebase Crashlytics, Sentry, PLCrashReporter) capture exception details, stack traces, and contextual data at the time of a crash. This information may include sensitive runtime state, depending on SDK configuration.
+
+**Network Request Logging**: iOS networking APIs and third-party libraries may log request and response data during debugging. The default `NSURLSession` configuration includes caching that can persist sensitive data. Network diagnostic logging features can expose additional details about HTTP traffic.
+
+**WKWebView Console Output**: Applications embedding web content via `WKWebView` or the deprecated `UIWebView` may capture JavaScript console output through message handlers. This can include data passed between web and native contexts.


### PR DESCRIPTION
Adds a small documentation update to MASTG-KNOW-0101 describing additional logging sources (native libraries, crash reporting tools, networking debug logs, and WebView/JavaScript logs) that may inadvertently expose sensitive information.

Addresses issue #3589.