### PR TITLE
Fix Chaining Constructor Recursion in frida.re 

### DIFF
--- a/utils/frida/android/base_script.js
+++ b/utils/frida/android/base_script.js
@@ -109,7 +109,12 @@ function registerHook(
     };
 
     try {
-      let returnValue = this[method].apply(this, arguments);
+      let returnValue;
+      if (method === "$init") {
+        returnValue = toHook.overloads[overloadIndex].apply(this, arguments);
+      } else {
+        returnValue = this[method].apply(this, arguments);
+      }
       event.returnValue = decodeArguments([returnType], [returnValue]);
       console.log(JSON.stringify(event, null, 2))
       return returnValue;


### PR DESCRIPTION
## Description

There was an issue with constructor chaining when all overloaded constructors were hooked. An example:

Left is the constructor overload, right an example:

```
1. URL(String spec)                                          URL("https://mas.owasp.org")

2. URL(URL context, String spec)                             URL(null, "https://mas.owasp.org")

3. URL(URL context, String spec, URLStreamHandler handler)   URL(null, "https://mas.owasp.org", null)
```

So when calling the original method using `this[method].apply(this, arguments);`, it seems that the already hooked function is called again, which then caused errors and twice the calls.

The following output shows that the constructors were called 6 times in total, and the object is not properly initiated (`NullPointerException`):

```json
{
  "id": "e4046b53-2924-4131-8c40-32b575f9a223",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.814Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:316)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:339)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:498)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    },
    {
      "declaredType": "int",
      "value": -1
    },
    {
      "declaredType": "java.lang.String",
      "value": "void"
    },
    {
      "declaredType": "java.net.URLStreamHandler",
      "value": "void"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
{
  "id": "490bcc90-a008-470c-a937-9ebf9c3069a2",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.812Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:339)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:498)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    },
    {
      "declaredType": "int",
      "value": -1
    },
    {
      "declaredType": "java.lang.String",
      "value": "void"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
{
  "id": "5c160856-4dcf-43e1-91e2-6298a591396e",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.811Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:498)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    },
    {
      "declaredType": "java.lang.String",
      "value": "void"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
{
  "id": "81061c98-4b22-4b4a-bd71-eba054c35f2e",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.810Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:498)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.net.URL",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    },
    {
      "declaredType": "java.net.URLStreamHandler",
      "value": "void"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
{
  "id": "29b07416-88fa-49f5-95f9-d1cdc5120f8f",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.809Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.net.URL",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
{
  "id": "81fb436e-61cf-469e-b208-6d278b5a554b",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:28:57.806Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "exception": "Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase()' on a null object reference"
}
```


The patch now calls the original constructor before it was hooked, and it seems to work as intended:


```json
{
  "id": "81ef0724-7b7d-4ca8-9aca-667af856ad38",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:29:38.371Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:498)",
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.net.URL",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    },
    {
      "declaredType": "java.net.URLStreamHandler",
      "value": "void"
    }
  ],
  "returnValue": [
    {
      "declaredType": "void",
      "value": "void"
    }
  ]
}
{
  "id": "8a4f89b4-0ac8-4563-a58f-7109532c37d5",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:29:38.370Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "java.net.URL.<init>(URL.java:447)",
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.net.URL",
      "value": "void"
    },
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "returnValue": [
    {
      "declaredType": "void",
      "value": "void"
    }
  ]
}
{
  "id": "009bf0a6-b908-40e7-9b9e-22af1f778138",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T12:29:38.368Z",
  "class": "java.net.URL",
  "method": "$init",
  "instanceId": 61589359,
  "stackTrace": [
    "java.net.URL.<init>(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:36)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "returnValue": [
    {
      "declaredType": "void",
      "value": "void"
    }
  ]
}
```

Now, to be honest, I'm not 100% sure why this was an issue. 

Other variants like `this.$init.apply(this, arguments);` also did not work. Also, the issue only occurred when chained constructors were hooked. 

I tested it with various cases. It works fine, but I don't fully understand why. Any ideas?

-------------------
[x] I have read the contributing guidelines.