### PR TITLE
Fix Instance ID lookup for static methods in frida.re

### DIFF
--- a/utils/frida/android/base_script.js
+++ b/utils/frida/android/base_script.js
@@ -84,7 +84,7 @@ function registerHook(
     let returnType = parseReturnValue(methodHeader);
 
     let instanceId;
-    if (this && this.$className && typeof this.$h === 'undefined') {
+    if (this && this.$className && this.$h === null) {
       instanceId = 'static';
     } else {
       // call Java’s identityHashCode on the real object


### PR DESCRIPTION
## Description

When hooking static methods, the frida.re script was not able to find out that the method is static. 

An example with the static method `static Uri parse(String uriString)`

```json
Error in identityHashCode Error: identityHashCode(): argument types do not match any of:
	.overload('java.lang.Object')
{
  "id": "d895b887-2748-4326-8d35-693a3a6f04c7",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T15:25:39.210Z",
  "class": "android.net.Uri",
  "method": "parse",
  "instanceId": "error",
  "stackTrace": [
    "android.net.Uri.parse(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:149)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "returnValue": [
    {
      "declaredType": "android.net.Uri",
      "value": "https://mas.owasp.org",
      "runtimeType": "android.net.Uri$StringUri",
      "instanceId": "226994437",
      "instanceToString": "https://mas.owasp.org"
    }
  ]
}
```

The problem was that `this.$h` is `null` and `typeof null = object`. With `this.$h === null` static methodes are properly identified:

```json
{
  "id": "820d10aa-b2cf-4a08-81f7-e90c3fe001e3",
  "type": "hook",
  "category": "NETWORK",
  "time": "2026-01-09T15:40:33.337Z",
  "class": "android.net.Uri",
  "method": "parse",
  "instanceId": "static",
  "stackTrace": [
    "android.net.Uri.parse(Native Method)",
    "org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:149)",
    "org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$12$lambda$11(MainActivity.kt:101)",
    "org.owasp.mastestapp.MainActivityKt.$r8$lambda$Pm6AsbKBmypP53K-UABM21E_Xxk(Unknown Source:0)",
    "org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda3.run(D8$$SyntheticClass:0)",
    "java.lang.Thread.run(Thread.java:1119)"
  ],
  "inputParameters": [
    {
      "declaredType": "java.lang.String",
      "value": "https://mas.owasp.org"
    }
  ],
  "returnValue": [
    {
      "declaredType": "android.net.Uri",
      "value": "https://mas.owasp.org",
      "runtimeType": "android.net.Uri$StringUri",
      "instanceId": "61589359",
      "instanceToString": "https://mas.owasp.org"
    }
  ]
}
```


-------------------


[x] I have read the contributing guidelines.
