### PR TITLE
Fix for code scanning alert: Incomplete URL substring sanitization

### DIFF
--- a/src/scripts/tools_healthcheck.py
+++ b/src/scripts/tools_healthcheck.py
@@ -1,6 +1,7 @@
 import os
 import re
 import yaml
+from urllib.parse import urlparse
 
 def extract_frontmatter(file_path):
     try:
@@ -32,7 +33,6 @@ for frontmatter in frontmatters:
     name = frontmatter.get('title', '')
     platform = frontmatter.get('platform', '')
     source = frontmatter.get('source', '')
-    from urllib.parse import urlparse
     parsed_url = urlparse(source)
     github_link = source if parsed_url.hostname == 'github.com' else ''
     if github_link:


### PR DESCRIPTION
Potential fix for [https://github.com/OWASP/mastg/security/code-scanning/1](https://github.com/OWASP/mastg/security/code-scanning/1)

To fix the issue, the code should parse the URL using `urllib.parse.urlparse` and validate that the hostname is exactly `github.com`. This ensures that the URL is properly structured and points to the intended domain. The fix involves replacing the substring check `'github.com' in source` with a more robust check using `urlparse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
