### PR TITLE
Use project-local .tmp directory for frida scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ site/
 .cache/
 references.json
 .obsidian/
+.tmp/

--- a/utils/frida/android/run.sh
+++ b/utils/frida/android/run.sh
@@ -6,6 +6,14 @@ decoderScript=$(cat "$(dirname $0)"/android_decoder.js)
 fridaScript=$(cat "$(dirname $0)"/base_script.js)
 randomNumber=$RANDOM
 
+# use project-local temp directory instead of global /tmp
+workDir="$(pwd)/.tmp"
+scriptPath="$workDir/frida_script_$randomNumber.js"
+
+# ensure temp directory exists
+mkdir -p "$workDir"
+
+
 # merging the different parts of the frida.re scripts and writing it to a temporary file
 {
   echo "$hook"
@@ -13,10 +21,11 @@ randomNumber=$RANDOM
   echo "$decoderScript"
   echo $'\n'
   echo "$fridaScript"
-}  > /tmp/frida_script_$randomNumber.js
+}   > "$scriptPath"
+
 
 # run the merged frida.re script
-frida -U -f org.owasp.mastestapp -l /tmp/frida_script_$randomNumber.js -o output.json
+frida -U -f org.owasp.mastestapp -l "$scriptPath" -o output.json
 
 # cleanup
-rm /tmp/frida_script_$randomNumber.js
+rm "$scriptPath"


### PR DESCRIPTION
- Use a project-local temporary directory instead of /tmp
- Add .tmp/ to .gitignore
- Avoid global temp files and improve safety
