### PR TITLE
Refactor moderator workflow to use event payload

### DIFF
--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -19,29 +19,25 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          ACTOR: ${{ github.actor }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           python - << 'PY'
-          import os
-      
+          import os, json
+
           event = (os.environ.get("EVENT_NAME") or "").strip()
-          actor = (os.environ.get("ACTOR") or "").strip().lower()
-          pr_author = (os.environ.get("PR_AUTHOR") or "").strip().lower()
-          issue_author = (os.environ.get("ISSUE_AUTHOR") or "").strip().lower()
-      
-          allow = {"cpholguera", "sushi2k", "Copilot"}
-      
+
+          payload_path = os.environ.get("GITHUB_EVENT_PATH") or ""
+          payload = {}
+          if payload_path:
+            with open(payload_path, "r", encoding="utf-8") as f:
+              payload = json.load(f)
+
+          subject = ""
           if event in ("pull_request", "pull_request_target"):
-            subject = pr_author
-          elif event == "issues":
-            subject = issue_author
-          else:
-            subject = actor
-      
-          skip = "true" if subject in allow else "false"
-      
+            subject = (payload.get("pull_request", {}).get("user", {}).get("login") or "").strip().lower()
+
+          allow = {"cpholguera", "sushi2k", "copilot"}
+          skip = "true" if subject and subject in allow else "false"
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
             f.write(f"skip={skip}\n")
             f.write(f"allow_subject={subject}\n")


### PR DESCRIPTION
For pull_request_target opened, the event payload available at the path in github.event_path and the environment variable GITHUB_EVENT_PATH contains pull_request, and pull_request.user.login is the PR author, so the step will correctly read the author from that JSON and compare to our allowlist.

It also fixes the allowlist match by lowercasing the subject and using a lowercase copilot entry.

Note that for workflow_dispatch there is no pull_request object in the payload, so subject will be empty and skip will be false, meaning the moderation steps will run on manual runs, unless we add a separate input or a different allow rule for workflow_dispatch.