### PR TITLE
add *.java

### DIFF
--- a/.github/workflows/spell-checker-pr.yml
+++ b/.github/workflows/spell-checker-pr.yml
@@ -24,6 +24,6 @@ jobs:
         uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
-          skip: "*.json,*.yml,*.apk,*.ipa,*.svg,*.txt,*.kt,*.swift,*.xml"
+          skip: "*.json,*.yml,*.apk,*.ipa,*.svg,*.txt,*.kt,*.swift,*.xml,*.java"
           ignore_words_list: "aas,aaS,ba,bund,compliancy,firt,ist,keypair,ligh,Manuel,Manual,ro,ser,synopsys,theses,zuser,lief,EDE"
           path: ${{ env.CHANGED_FILES }}

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           ignore_words_list: "aas,aaS,ba,bund,compliancy,firt,ist,keypair,ligh,Manuel,Manual,ro,ser,synopsys,theses,zuser,lief,EDE"
-          skip: "*.json,*.yml,*.apk,*.ipa,*.svg,*.txt,*.kt,*.swift,*.xml"
+          skip: "*.json,*.yml,*.apk,*.ipa,*.svg,*.txt,*.kt,*.swift,*.xml,*.java"


### PR DESCRIPTION
This pull request makes a minor update to the spell checker workflow configuration. The change ensures that Java files are now excluded from automated spell checking in both pull request and main branch workflows.

* Updated the `skip` pattern in both `.github/workflows/spell-checker.yml` and `.github/workflows/spell-checker-pr.yml` to add `*.java`, so that Java files will not be checked by the spell checker. [[1]](diffhunk://#diff-9ca9b759969790585021d09b672f371fe0b979553ea714a1225174f314d91f65L17-R17) [[2]](diffhunk://#diff-cb2d135bfa065ba867f8bbe494a9de36f80d64f9a01b3faa0e14a59ce8cdfe0eL27-R27)