### PR TITLE
Add technique for non-jailbroken iOS dynamic analysis (#3724)

### DIFF
--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -96,7 +96,7 @@ You can usually bypass the installation restriction just to get the decrypted bi
 
 1. Extract the FairPlay-encrypted IPA via [Apple Configurator](https://support.apple.com/apple-configurator).
 2. Unzip the archive and modify the `MinimumOSVersion` key within the `Info.plist` file to match the older jailbroken device's iOS version.
-3. Repackage and force-install the app. Please refer to @MASTG-TECH-0056 for standard app installation methods. If standard methods fail due to the version mismatch, using a tweak like AppSync Unified (@MASTG-TOOL-0127) is a common workaround.
+3. Repackage and force-install the app. Please refer to @MASTG-TECH-0056 for standard app installation methods. If standard methods fail due to the version mismatch, using a tweak like @MASTG-TOOL-0127 is a common workaround.
 4. The app will probably crash right away due to missing modern APIs. However, the decrypted Mach-O binary is usually already loaded in memory. You can dump it during this early initialization stage using standard tools like @MASTG-TOOL-0050 (`frida-ios-dump`). Once you have the decrypted payload, just transfer it to your modern non-jailbroken device for patching.
 
 ## Thinning the App Binary

--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -86,6 +86,19 @@ rabin2 -I Payload/Telegram X.app/Telegram X | grep crypto
 crypto   false
 ```
 
+### Overcoming Decryption Constraints (Version Mismatch)
+
+You might run into a situation where the target app requires a newer iOS version (like iOS 16+), but your jailbroken device is stuck on an older version (like iOS 14).
+
+**The MinimumOSVersion Workaround:**
+
+You can usually bypass the installation restriction just to get the decrypted binary (based on [this workaround](https://book.hacktricks.wiki/en/mobile-pentesting/ios-pentesting/ios-pentesting-without-jailbreak.html)):
+
+1. Extract the FairPlay-encrypted IPA via [Apple Configurator](https://support.apple.com/apple-configurator).
+2. Unzip the archive and modify the `MinimumOSVersion` key within the `Info.plist` file to match the older jailbroken device's iOS version.
+3. Repackage and force-install the app. Please refer to @MASTG-TECH-0056 for standard app installation methods. If standard methods fail due to the version mismatch, using a tweak like AppSync Unified (@MASTG-TOOL-0127) is a common workaround.
+4. The app will probably crash right away due to missing modern APIs. However, the decrypted Mach-O binary is usually already loaded in memory. You can dump it during this early initialization stage using standard tools like @MASTG-TOOL-0050 (`frida-ios-dump`). Once you have the decrypted payload, just transfer it to your modern non-jailbroken device for patching.
+
 ## Thinning the App Binary
 
 The app binary may contain multiple architectures, such as `armv7` (32-bit) and `arm64` (64-bit). That is called a "fat binary".

--- a/techniques/ios/MASTG-TECH-0056.md
+++ b/techniques/ios/MASTG-TECH-0056.md
@@ -88,8 +88,8 @@ It is also possible to use the Xcode IDE to install iOS apps by executing the fo
 
 Standard free Apple developer accounts restrict app provisioning profiles to just seven days. For extended testing periods, this requires constant re-tethering to a workstation. To maintain persistence locally on the device, consider these sideloading methods:
 
-- **SideStore (@MASTG-TOOL-0150):** This tool handles profile renewals directly on the device. It works by routing the signing traffic wirelessly through a local WireGuard loopback.
-- **TrollStore (@MASTG-TOOL-0151):** If the testing device runs an iOS version susceptible to the CoreTrust vulnerability, you can use TrollStore. It essentially allows user-signed applications to be installed permanently, completely bypassing the seven-day expiration.
+- @MASTG-TOOL-0150: This tool handles profile renewals directly on the device. It works by routing the signing traffic wirelessly through a local WireGuard loopback.
+- @MASTG-TOOL-0151: If the testing device runs an iOS version susceptible to the CoreTrust vulnerability, you can use TrollStore. It essentially allows user-signed applications to be installed permanently, completely bypassing the seven-day expiration.
 
 ## Allow Application Installation on a Non-iPad Device
 

--- a/techniques/ios/MASTG-TECH-0056.md
+++ b/techniques/ios/MASTG-TECH-0056.md
@@ -84,6 +84,13 @@ It is also possible to use the Xcode IDE to install iOS apps by executing the fo
 2. Select **Window/Devices and Simulators**
 3. Select the connected iOS device and click on the **+** sign in **Installed Apps**.
 
+## Modern Sideloading for Persistence
+
+Standard free Apple developer accounts restrict app provisioning profiles to just seven days. For extended testing periods, this requires constant re-tethering to a workstation. To maintain persistence locally on the device, consider these sideloading methods:
+
+- **SideStore (@MASTG-TOOL-0150):** This tool handles profile renewals directly on the device. It works by routing the signing traffic wirelessly through a local WireGuard loopback.
+- **TrollStore (@MASTG-TOOL-0151):** If the testing device runs an iOS version susceptible to the CoreTrust vulnerability, you can use TrollStore. It essentially allows user-signed applications to be installed permanently, completely bypassing the seven-day expiration.
+
 ## Allow Application Installation on a Non-iPad Device
 
 Sometimes an application must be used on an iPad. If you only have iPhone or iPod touch devices, you can force the application to be installed and used on these devices. You can do this by changing the value of the property **UIDeviceFamily** to the value **1** in the **Info.plist** file.

--- a/techniques/ios/MASTG-TECH-0146.md
+++ b/techniques/ios/MASTG-TECH-0146.md
@@ -14,19 +14,6 @@ The following sections walk through each step of the process for App Store apps:
 
 Follow @MASTG-TECH-0054 to obtain the IPA file for the app you want to test and ensure you obtain a **non-encrypted version before proceeding** (you'll need a jailbroken device).
 
-### Overcoming Decryption Constraints (Version Mismatch)
-
-You might run into a situation where the target app requires a newer iOS version (like iOS 16+), but your jailbroken device is stuck on an older version (like iOS 14).
-
-**The MinimumOSVersion Workaround:**
-
-You can usually bypass the installation restriction just to get the decrypted binary:
-
-1. Extract the FairPlay-encrypted IPA via Apple Configurator.
-2. Unzip the archive and modify the `MinimumOSVersion` key within the `Info.plist` file to match the older jailbroken device's iOS version.
-3. Repackage and force-install the app using a tweak like AppSync Unified.
-4. The app will probably crash right away due to missing modern APIs. However, the decrypted Mach-O binary is usually already loaded in memory. You can dump it during this early initialization stage using standard tools like `frida-ios-dump`. Once you have the decrypted payload, just transfer it to your modern non-jailbroken device for patching.
-
 ## Step 2: Obtain a Developer Provisioning Profile
 
 Follow @MASTG-TECH-0079 to create a signing identity and obtain a valid provisioning profile. You'll need this to sign the repackaged IPA so iOS allows it to run on your device.
@@ -43,26 +30,9 @@ Follow @MASTG-TECH-0092 to re-sign the patched IPA using the provisioning profil
 
 Follow @MASTG-TECH-0056 to install the signed IPA on your device. Note that because you've modified the IPA, the Bundle Identifier may have changed depending on the signing tool you used.
 
-### Modern Sideloading for Persistence
-
-Standard free Apple developer accounts restrict app provisioning profiles to just seven days. For extended testing periods, this requires constant re-tethering to a workstation. To maintain persistence locally on the device, consider these sideloading methods:
-
-- **SideStore:** This tool handles profile renewals directly on the device. It works by routing the signing traffic wirelessly through a local WireGuard loopback.
-- **TrollStore:** If the testing device runs an iOS version susceptible to the CoreTrust vulnerability, you can use TrollStore. It essentially allows user-signed applications to be installed permanently, completely bypassing the seven-day expiration.
-
 ## Step 6: Launch the App in Debug Mode
 
 Follow @MASTG-TECH-0055 to launch the repackaged app in debug mode. Launching via SpringBoard will cause it to crash; you must use the debug launch method so the Frida Gadget can start and wait for your connection.
-
-## Automated Dynamic Analysis with MobSF
-
-You can also use Mobile Security Framework (MobSF) for automated dynamic instrumentation. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the `usbmuxd` socket:
-
-```bash
-docker run -it --rm -p 8000:8000 -v /var/run/usbmuxd:/var/run/usbmuxd opensecurity/mobile-security-framework-mobsf:latest
-```
-
-Once the container has USB access, upload your repackaged and developer-signed IPA to the MobSF web interface. MobSF handles the deployment, starts the Frida session inside the app sandbox, and generates the dynamic analysis report.
 
 ## Troubleshooting and Modern iOS Caveats (iOS 16+)
 

--- a/techniques/ios/MASTG-TECH-0146.md
+++ b/techniques/ios/MASTG-TECH-0146.md
@@ -14,6 +14,19 @@ The following sections walk through each step of the process for App Store apps:
 
 Follow @MASTG-TECH-0054 to obtain the IPA file for the app you want to test and ensure you obtain a **non-encrypted version before proceeding** (you'll need a jailbroken device).
 
+### Overcoming Decryption Constraints (Version Mismatch)
+
+You might run into a situation where the target app requires a newer iOS version (like iOS 16+), but your jailbroken device is stuck on an older version (like iOS 14).
+
+**The MinimumOSVersion Workaround:**
+
+You can usually bypass the installation restriction just to get the decrypted binary:
+
+1. Extract the FairPlay-encrypted IPA via Apple Configurator.
+2. Unzip the archive and modify the `MinimumOSVersion` key within the `Info.plist` file to match the older jailbroken device's iOS version.
+3. Repackage and force-install the app using a tweak like AppSync Unified.
+4. The app will probably crash right away due to missing modern APIs. However, the decrypted Mach-O binary is usually already loaded in memory. You can dump it during this early initialization stage using standard tools like `frida-ios-dump`. Once you have the decrypted payload, just transfer it to your modern non-jailbroken device for patching.
+
 ## Step 2: Obtain a Developer Provisioning Profile
 
 Follow @MASTG-TECH-0079 to create a signing identity and obtain a valid provisioning profile. You'll need this to sign the repackaged IPA so iOS allows it to run on your device.
@@ -30,6 +43,35 @@ Follow @MASTG-TECH-0092 to re-sign the patched IPA using the provisioning profil
 
 Follow @MASTG-TECH-0056 to install the signed IPA on your device. Note that because you've modified the IPA, the Bundle Identifier may have changed depending on the signing tool you used.
 
+### Modern Sideloading for Persistence
+
+Standard free Apple developer accounts restrict app provisioning profiles to just seven days. For extended testing periods, this requires constant re-tethering to a workstation. To maintain persistence locally on the device, consider these sideloading methods:
+
+- **SideStore:** This tool handles profile renewals directly on the device. It works by routing the signing traffic wirelessly through a local WireGuard loopback.
+- **TrollStore:** If the testing device runs an iOS version susceptible to the CoreTrust vulnerability, you can use TrollStore. It essentially allows user-signed applications to be installed permanently, completely bypassing the seven-day expiration.
+
 ## Step 6: Launch the App in Debug Mode
 
 Follow @MASTG-TECH-0055 to launch the repackaged app in debug mode. Launching via SpringBoard will cause it to crash; you must use the debug launch method so the Frida Gadget can start and wait for your connection.
+
+## Automated Dynamic Analysis with MobSF
+
+You can also use Mobile Security Framework (MobSF) for automated dynamic instrumentation. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the `usbmuxd` socket:
+
+```bash
+docker run -it --rm -p 8000:8000 -v /var/run/usbmuxd:/var/run/usbmuxd opensecurity/mobile-security-framework-mobsf:latest
+```
+
+Once the container has USB access, upload your repackaged and developer-signed IPA to the MobSF web interface. MobSF handles the deployment, starts the Frida session inside the app sandbox, and generates the dynamic analysis report.
+
+## Troubleshooting and Modern iOS Caveats (iOS 16+)
+
+Keep these modern platform protections in mind, as they can easily break your dynamic analysis setup.
+
+**Lockdown Mode:**
+
+If this is enabled, it blocks `dyld` from loading externally signed dynamic libraries. Your injected Frida Gadget won't load, and the app will either crash or ignore your instrumentation attempts. Make sure Lockdown Mode is turned off before starting.
+
+**Pointer Authentication (PAC):**
+
+A12+ chips enforce strict memory protections. Make sure you are using Frida 16.0 or newer. Older versions don't handle PAC stripping transparently, so the patched binary will immediately throw `SIGBUS` or `SIGSEGV` crashes when trying to execute instrumented code.

--- a/tools/generic/MASTG-TOOL-0035.md
+++ b/tools/generic/MASTG-TOOL-0035.md
@@ -25,7 +25,7 @@ setup.bat # For Windows
 run.bat # For Windows
 ```
 
-Once you have MobSF up and running you can open it in your browser by navigating to <http://127.0.0.1:8000>. Simply drag the APK you want to analyze into the upload area and MobSF will start its job.
+Once you have MobSF up and running you can open it in your browser by navigating to <http://127.0.0.1:8000>. Simply drag the APK or IPA you want to analyze into the upload area and MobSF will start its job.
 
 While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on jailbroken VMs, you can still perform dynamic analysis on physical non-jailbroken devices. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the @MASTG-TOOL-0069 (usbmuxd) socket:
 

--- a/tools/generic/MASTG-TOOL-0035.md
+++ b/tools/generic/MASTG-TOOL-0035.md
@@ -26,3 +26,11 @@ run.bat # For Windows
 ```
 
 Once you have MobSF up and running you can open it in your browser by navigating to <http://127.0.0.1:8000>. Simply drag the APK you want to analyze into the upload area and MobSF will start its job.
+
+While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on jailbroken VMs, you can still perform dynamic analysis on physical non-jailbroken devices. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the @MASTG-TOOL-0069 (usbmuxd) socket:
+
+```bash
+docker run -it --rm -p 8000:8000 -v /var/run/usbmuxd:/var/run/usbmuxd opensecurity/mobile-security-framework-mobsf:latest
+```
+
+Once the container has USB access, upload your repackaged IPA to the MobSF web interface.

--- a/tools/generic/MASTG-TOOL-0035.md
+++ b/tools/generic/MASTG-TOOL-0035.md
@@ -27,10 +27,16 @@ run.bat # For Windows
 
 Once you have MobSF up and running you can open it in your browser by navigating to <http://127.0.0.1:8000>. Simply drag the APK or IPA you want to analyze into the upload area and MobSF will start its job.
 
-While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on virtual jailbroken devices, you can still perform dynamic analysis on physical non-jailbroken devices. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the @MASTG-TOOL-0069 socket:
+While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on virtual jailbroken or rooted devices, you can still perform dynamic analysis on physical non-jailbroken devices.
+
+If you're running MobSF in Docker and need it to communicate with a physical iOS device via USB, make sure to mount the @MASTG-TOOL-0069 socket. For Android physical devices, you would typically pass the USB device directly using `--device /dev/bus/usb` or connect via ADB over TCP:
 
 ```bash
+# Example for iOS (mounting usbmuxd):
 docker run -it --rm -p 8000:8000 -v /var/run/usbmuxd:/var/run/usbmuxd opensecurity/mobile-security-framework-mobsf:latest
+
+# Example for Android (direct USB access):
+docker run -it --rm -p 8000:8000 --device /dev/bus/usb opensecurity/mobile-security-framework-mobsf:latest
 ```
 
-Once the container has USB access, upload your repackaged IPA to the MobSF web interface.
+Once the container has USB access, upload your APK or repackaged IPA to the MobSF web interface.

--- a/tools/generic/MASTG-TOOL-0035.md
+++ b/tools/generic/MASTG-TOOL-0035.md
@@ -27,7 +27,7 @@ run.bat # For Windows
 
 Once you have MobSF up and running you can open it in your browser by navigating to <http://127.0.0.1:8000>. Simply drag the APK or IPA you want to analyze into the upload area and MobSF will start its job.
 
-While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on jailbroken VMs, you can still perform dynamic analysis on physical non-jailbroken devices. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the @MASTG-TOOL-0069 (usbmuxd) socket:
+While the [official MobSF documentation](https://mobsf.github.io/docs/#/dynamic_analyzer_docker) focuses on virtual jailbroken devices, you can still perform dynamic analysis on physical non-jailbroken devices. If you're running MobSF in Docker and need it to communicate with the physical device via USB, make sure to mount the @MASTG-TOOL-0069 socket:
 
 ```bash
 docker run -it --rm -p 8000:8000 -v /var/run/usbmuxd:/var/run/usbmuxd opensecurity/mobile-security-framework-mobsf:latest

--- a/tools/ios/MASTG-TOOL-0150.md
+++ b/tools/ios/MASTG-TOOL-0150.md
@@ -1,0 +1,7 @@
+---
+title: SideStore
+platform: ios
+source: https://sidestore.io/
+---
+
+SideStore is an iOS sideloading app that allows you to sign and install apps using your Apple ID, bypassing the 7-day limit by refreshing them on-device via a local WireGuard VPN.

--- a/tools/ios/MASTG-TOOL-0150.md
+++ b/tools/ios/MASTG-TOOL-0150.md
@@ -4,4 +4,4 @@ platform: ios
 source: https://sidestore.io/
 ---
 
-SideStore is an iOS sideloading app that allows you to sign and install apps using your Apple ID, bypassing the 7-day limit by refreshing them on-device via a local WireGuard VPN.
+SideStore is an iOS sideloading app that allows you to sign and install apps using your Apple ID, bypassing the seven-day limit by refreshing them on-device via a local WireGuard VPN.

--- a/tools/ios/MASTG-TOOL-0151.md
+++ b/tools/ios/MASTG-TOOL-0151.md
@@ -4,4 +4,4 @@ platform: ios
 source: https://github.com/opa334/TrollStore
 ---
 
-TrollStore is a permasigned jailed app that can permanently install any IPA you open in it, exploiting the CoreTrust bug on specific iOS versions to bypass the standard seven-day expiration.
+TrollStore is a permanently signed jailed app that can permanently install any IPA you open in it, exploiting the CoreTrust bug on specific iOS versions to bypass the standard seven-day expiration.

--- a/tools/ios/MASTG-TOOL-0151.md
+++ b/tools/ios/MASTG-TOOL-0151.md
@@ -1,0 +1,7 @@
+---
+title: TrollStore
+platform: ios
+source: https://github.com/opa334/TrollStore
+---
+
+TrollStore is a permasigned jailed app that can permanently install any IPA you open in it, exploiting the CoreTrust bug on specific iOS versions to bypass the standard seven-day expiration.


### PR DESCRIPTION
## Description

Adds a technique for dynamic analysis on non-jailbroken iOS devices. This follows the discussion in the issue and documents the decryption and sideloading approach used in practice.

Linted locally with `markdownlint-cli2`.

---

## AI Tool Disclosure

- [x] This contribution does not include AI-generated content.
- [ ] This contribution includes AI-generated content.

---

## Contributor Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I followed the project style guide.
- [x] I validated the technical correctness of my changes.
- [x] This PR adds clear value and is not spam or low-effort content.

Closes #3724