### PR TITLE
Update MASTG-KNOW-0017.md

### DIFF
--- a/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0017.md
+++ b/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0017.md
@@ -47,6 +47,7 @@ Independently from the assigned Protection Level, it is important to consider th
 | **CRITICAL** | `android.permission.RECORD_SENSITIVE_CONTENT` | signature |
 | **CRITICAL** | `android.permission.RECEIVE_SENSITIVE_NOTIFICATIONS` | signature |
 | **CRITICAL** | `android.permission.DYNAMIC_INSTRUMENTATION` | signature |
+| **CRITICAL** | `android.permission.BIND_ACCESSIBILITY_SERVICE` | signature |
 | **HIGH** | `android.permission.INSTALL_GRANT_RUNTIME_PERMISSIONS` | signature |
 | **HIGH** | `android.permission.READ_SMS` | dangerous |
 | **HIGH** | `android.permission.WRITE_SMS` | normal |
@@ -58,7 +59,6 @@ Independently from the assigned Protection Level, it is important to consider th
 | **HIGH** | `android.permission.LOCATION_HARDWARE` | signature |
 | **HIGH** | `android.permission.ACCESS_FINE_LOCATION` | dangerous |
 | **HIGH** | `android.permission.ACCESS_BACKGROUND_LOCATION` | dangerous |
-| **HIGH** | `android.permission.BIND_ACCESSIBILITY_SERVICE` | signature |
 | **HIGH** | `android.permission.ACCESS_WIFI_STATE` | normal |
 | **HIGH** | `com.android.voicemail.permission.READ_VOICEMAIL` | signature |
 | **HIGH** | `android.permission.RECORD_AUDIO` | dangerous |


### PR DESCRIPTION
Relates to issue https://github.com/OWASP/mastg/issues/3741

## Description

Updated risk category for android.permission.BIND_ACCESSIBILITY_SERVICE that was previously overlooked. 

---

## AI Tool Disclosure

Check exactly one option.

- [X] This contribution does not include AI-generated content.
- [ ] This contribution includes AI-generated content.

---

## Contributor Checklist

- [x ] I have read and understood the contributing guidelines.
- [ x] I followed the project style guide.
- [x] I validated the technical correctness of my changes and understand the topic.
- [ x] This PR adds clear value and is not spam or low-effort content.

Relevant documentation.

- [General Contributing Guidelines](https://mas.owasp.org/contributing/)
- [Style Guide](https://mas.owasp.org/contributing/5_Style_Guide/)
- [Porting MASTG v1 Tests to v2](https://github.com/OWASP/mastg/blob/master/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md)
- [Instructions for new MASTG components](https://github.com/OWASP/mastg/tree/master/.github/instructions)

Contributors are expected to understand basic git and GitHub workflows, including forks, branches, commits, and pull requests. The project does not provide training. Pull requests that do not meet these minimum requirements may be closed without review.
