### PR TITLE
Update risk category for android.permission.BIND_ACCESSIBILITY_SERVICE in MASTG-KNOW-0017.md

### DIFF
--- a/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0017.md
+++ b/knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0017.md
@@ -47,6 +47,7 @@ Independently from the assigned Protection Level, it is important to consider th
 | **CRITICAL** | `android.permission.RECORD_SENSITIVE_CONTENT` | signature |
 | **CRITICAL** | `android.permission.RECEIVE_SENSITIVE_NOTIFICATIONS` | signature |
 | **CRITICAL** | `android.permission.DYNAMIC_INSTRUMENTATION` | signature |
+| **CRITICAL** | `android.permission.BIND_ACCESSIBILITY_SERVICE` | signature |
 | **HIGH** | `android.permission.INSTALL_GRANT_RUNTIME_PERMISSIONS` | signature |
 | **HIGH** | `android.permission.READ_SMS` | dangerous |
 | **HIGH** | `android.permission.WRITE_SMS` | normal |
@@ -58,7 +59,6 @@ Independently from the assigned Protection Level, it is important to consider th
 | **HIGH** | `android.permission.LOCATION_HARDWARE` | signature |
 | **HIGH** | `android.permission.ACCESS_FINE_LOCATION` | dangerous |
 | **HIGH** | `android.permission.ACCESS_BACKGROUND_LOCATION` | dangerous |
-| **HIGH** | `android.permission.BIND_ACCESSIBILITY_SERVICE` | signature |
 | **HIGH** | `android.permission.ACCESS_WIFI_STATE` | normal |
 | **HIGH** | `com.android.voicemail.permission.READ_VOICEMAIL` | signature |
 | **HIGH** | `android.permission.RECORD_AUDIO` | dangerous |


### PR DESCRIPTION
updated risk category for android.permission.BIND_ACCESSIBILITY_SERVICE

This PR closes #3741

## Description

This PR updates the risk category for android.permission.BIND_ACCESSIBILITY_SERVICE from HIGH to CRITICAL in knowledge/android/MASVS-PLATFORM/MASTG-KNOW-0017.md.

**Reasoning**: While android.permission.BIND_ACCESSIBILITY_SERVICE is a signature level permission intended for the Android system, it is one of the most powerful and frequently abused APIs in the Android ecosystem. 

Accessibility services have the capability to:

**Monitor UI Events:** Receive callbacks when state transitions occur, such as a button being clicked.
**Extract Sensitive Data**: Query the content of the active window and read text from other applications.
**Perform Actions:** Programmatically click on UI elements or set accessibility focus ([ source](https://github.com/OWASP/mastg/compare/master...annab-google:owasp-mastg:patch-1?content_ref=can+monitor+ui+events+click+on+elements+and+extract+text+from+othe)).
Due to these capabilities, Accessibility APIs are heavily targeted by Potentially Harmful Applications (PHAs) for phishing (extracting credentials from other app UIs), privilege escalation (preventing apps from being stopped), and hostile downloading. Elevating the risk category to CRITICAL aligns with the potential impact of its abuse in mobile security assessments.

---

## AI Tool Disclosure

Check exactly one option.

- [X] This contribution does not include AI-generated content.
- [ ] This contribution includes AI-generated content.

---

## Contributor Checklist

- [X] I have read and understood the contributing guidelines.
- [X] I followed the project style guide.
- [X] I validated the technical correctness of my changes and understand the topic.
- [X] This PR adds clear value and is not spam or low-effort content.

Relevant documentation.

- [General Contributing Guidelines](https://mas.owasp.org/contributing/)
- [Style Guide](https://mas.owasp.org/contributing/5_Style_Guide/)
- [Porting MASTG v1 Tests to v2](https://github.com/OWASP/mastg/blob/master/.github/instructions/porting-mastg-v1-tests-to-v2.instructions.md)
- [Instructions for new MASTG components](https://github.com/OWASP/mastg/tree/master/.github/instructions)

Contributors are expected to understand basic git and GitHub workflows, including forks, branches, commits, and pull requests. The project does not provide training. Pull requests that do not meet these minimum requirements may be closed without review.
